### PR TITLE
ECOSYS-96 Create Payara Domain from VSCode

### DIFF
--- a/package.json
+++ b/package.json
@@ -269,6 +269,8 @@
 	},
 	"dependencies": {
 		"@types/tail": "^2.0.0",
+		"@types/tmp": "^0.1.0",
+		"@types/validator": "^12.0.1",
 		"@types/xml2js": "^0.4.5",
 		"fs-extra": "^8.1.0",
 		"lodash": "^4.17.15",
@@ -276,20 +278,22 @@
 		"request": "^2.88.0",
 		"sync-request": "^6.1.0",
 		"tail": "^2.0.3",
+		"tmp": "^0.1.0",
+		"validator": "^12.2.0",
 		"xml2js": "^0.4.23"
 	},
 	"devDependencies": {
+		"@types/fs-extra": "^8.0.1",
 		"@types/glob": "^7.1.1",
+		"@types/lodash": "^4.14.149",
 		"@types/mocha": "^5.2.7",
 		"@types/node": "^12.11.7",
 		"@types/vscode": "^1.40.0",
-		"@types/fs-extra": "^8.0.1",
-		"@types/lodash": "^4.14.149",
 		"glob": "^7.1.5",
 		"mocha": "^6.2.2",
+		"os": "^0.1.1",
+		"tslint": "^5.20.1",
 		"typescript": "^3.6.4",
-		"tslint": "^5.20.0",
-		"vscode-test": "^1.2.2",
-		"os": "^0.1.1"
+		"vscode-test": "^1.2.2"
 	}
 }

--- a/src/main/extension.ts
+++ b/src/main/extension.ts
@@ -27,7 +27,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
 	const payaraInstanceProvider: PayaraInstanceProvider = new PayaraInstanceProvider(context);
 	const payaraServerTree: PayaraServerTreeDataProvider = new PayaraServerTreeDataProvider(context, payaraInstanceProvider);
-	const payaraInstanceController: PayaraInstanceController = new PayaraInstanceController(payaraInstanceProvider, context.extensionPath);
+	const payaraInstanceController: PayaraInstanceController = new PayaraInstanceController(context, payaraInstanceProvider, context.extensionPath);
 
 	context.subscriptions.push(
 		vscode.window.registerTreeDataProvider(

--- a/src/main/fish/payara/server/PayaraInstanceController.ts
+++ b/src/main/fish/payara/server/PayaraInstanceController.ts
@@ -22,14 +22,16 @@ import * as _ from "lodash";
 import * as path from "path";
 import * as open from "open";
 import * as fs from "fs";
+import * as tmp from "tmp";
 import * as fse from "fs-extra";
 import * as cp from 'child_process';
+import * as isPort from 'validator/lib/isPort';
 import * as ui from "./../../../UI";
 import { PayaraInstanceProvider } from "./PayaraInstanceProvider";
 import { PayaraServerInstance, InstanceState } from './PayaraServerInstance';
 import { JvmConfigReader } from './start/JvmConfigReader';
 import { JDKVersion } from './start/JDKVersion';
-import { QuickPickItem, CancellationToken, Uri } from 'vscode';
+import { QuickPickItem, CancellationToken, Uri, OutputChannel } from 'vscode';
 import { JvmOption } from './start/JvmOption';
 import { StringUtils } from './tooling/utils/StringUtils';
 import { ServerUtils } from './tooling/utils/ServerUtils';
@@ -38,11 +40,19 @@ import { StartTask } from './start/StartTask';
 import { ChildProcess } from 'child_process';
 import { RestEndpoints } from './endpoints/RestEndpoints';
 import { URL } from 'url';
+import { MyButton } from './../../../UI';
+import { FileResult } from 'tmp';
 
 export class PayaraInstanceController {
 
-    constructor(private instanceProvider: PayaraInstanceProvider, private extensionPath: string) {
+    private outputChannel: OutputChannel;
+
+    constructor(
+        private context: vscode.ExtensionContext,
+        private instanceProvider: PayaraInstanceProvider,
+        private extensionPath: string) {
         this.init();
+        this.outputChannel = vscode.window.createOutputChannel("payara");
     }
 
     private async init(): Promise<void> {
@@ -63,23 +73,349 @@ export class PayaraInstanceController {
     }
 
     public async addServer(): Promise<void> {
+        let controller = this;
         ui.MultiStepInput.run(
             input => this.selectServer(input,
                 {},
-                payaraServer => {
-                    this.instanceProvider.addServer(payaraServer);
-                    this.refreshServerList();
-                    payaraServer.checkAliveStatusUsingJPS(() => {
-                        payaraServer.setStarted(true);
-                        this.refreshServerList();
-                        payaraServer.connectOutput();
-                    });
+                state => {
+                    if (!state.name) {
+                        vscode.window.showErrorMessage('server name is invalid');
+                    } else if (!state.path) {
+                        vscode.window.showErrorMessage('selected server path is invalid');
+                    } else if (!state.domainName) {
+                        vscode.window.showErrorMessage('domain name is invalid');
+                    } else {
+                        let serverName = state.name;
+                        let serverPath = state.path;
+                        let domainName = state.domainName;
+
+                        let registerServer = () => {
+                            let payaraServer = new PayaraServerInstance(serverName, serverPath, domainName);
+                            this.instanceProvider.addServer(payaraServer);
+                            this.refreshServerList();
+                            payaraServer.checkAliveStatusUsingJPS(() => {
+                                payaraServer.setStarted(true);
+                                this.refreshServerList();
+                                payaraServer.connectOutput();
+                            });
+                        };
+                        if (state.newDomain) {
+                            controller.createDomain(
+                                registerServer,
+                                serverName,
+                                serverPath,
+                                domainName,
+                                state.adminPort,
+                                state.httpPort,
+                                state.username,
+                                state.password
+                            );
+                        } else {
+                            registerServer();
+                        }
+                    }
                 })
         );
     }
 
+    private DEFAULT_USERNAME: string = 'admin';
+    private DEFAULT_PASSWORD: string = '';
+    private MASTER_PASSWORD: string = 'changeit';
+    private DEFAULT_ADMIN_PORT: string = '4848';
+    private DEFAULT_HTTP_PORT: string = '8080';
+
+    private async createDomain(
+        callback: () => any,
+        serverName: string,
+        serverPath: string,
+        domainName: string,
+        adminPort?: string,
+        instancePort?: string,
+        username?: string,
+        password?: string) {
+
+        let passwordFile: FileResult;
+        if (!adminPort) {
+            adminPort = this.DEFAULT_ADMIN_PORT;
+        }
+        if (!instancePort) {
+            instancePort = this.DEFAULT_HTTP_PORT;
+        }
+        if (!username) {
+            username = this.DEFAULT_USERNAME;
+        }
+        if (!password) {
+            password = this.DEFAULT_PASSWORD;
+        }
+        let javaHome: string | undefined = JDKVersion.getDefaultJDKHome();
+        if (!javaHome) {
+            throw new Error("Java home path not found.");
+        }
+        let javaVmExe: string = JavaUtils.javaVmExecutableFullPath(javaHome);
+        let args: Array<string> = new Array<string>();
+        args.push("-client");
+        args.push("-jar");
+        args.push(path.join(serverPath, "glassfish", "modules", "admin-cli.jar"));
+        args.push("create-domain");
+        args.push("--domaindir");
+        args.push(path.join(serverPath, "glassfish", "domains"));
+        args.push("--adminport");
+        args.push(adminPort);
+        args.push("--instanceport");
+        args.push(instancePort);
+        args.push("--user");
+        args.push(username);
+        if (password === '') {
+            args.push("--nopassword");
+        } else {
+            passwordFile = this.createTempPasswordFile(password);
+            args.push("--passwordfile");
+            args.push(passwordFile.name);
+        }
+        args.push(domainName);
+        let process: ChildProcess = cp.spawn(javaVmExe, args, { cwd: serverPath });
+        if (process.pid) {
+            this.outputChannel.show(false);
+            this.outputChannel.append('Running the create-domain asadmin command ... \n');
+            let logCallback = (data: string | Buffer): void => this.outputChannel.append(data.toString());
+            if (process.stdout !== null) {
+                process.stdout.on('data', logCallback);
+            }
+            if (process.stderr !== null) {
+                process.stderr.on('data', logCallback);
+            }
+            process.on('error', (err: Error) => {
+                console.log('error: ' + err.message);
+            });
+            process.on('exit', (code: number) => {
+                if (code === 0) {
+                    callback();
+                } else {
+                    vscode.window.showErrorMessage('Command create-domain execution failed.');
+                }
+                if (passwordFile) {
+                    passwordFile.removeCallback();
+                }
+            });
+        }
+    }
+
+    private createTempPasswordFile(password: string): FileResult {
+        var tmpFile = tmp.fileSync({ prefix: 'payara-password-', postfix: '.txt' });
+        console.log('File: ', tmpFile.name);
+        let content = "AS_ADMIN_ADMINPASSWORD=" + password + '\n'; // to create domain
+        content += "AS_ADMIN_PASSWORD=" + password + '\n'; // to start domain
+        content += "AS_ADMIN_MASTERPASSWORD=" + this.MASTER_PASSWORD;
+        if (fs.existsSync(tmpFile.name)) {
+            fs.writeFileSync(tmpFile.name, content);
+        }
+        return tmpFile;
+    }
+
+    private async selectServer(input: ui.MultiStepInput, state: Partial<State>, callback: (n: Partial<State>) => any) {
+
+        const fileUris = await vscode.window.showOpenDialog({
+            defaultUri: vscode.workspace.rootPath ? vscode.Uri.file(vscode.workspace.rootPath) : undefined,
+            canSelectFiles: false,
+            canSelectFolders: true,
+            canSelectMany: false,
+            openLabel: 'Select Payara Server'
+        });
+        const serverPaths: vscode.Uri[] = fileUris ? fileUris : [] as vscode.Uri[];
+        if (_.isEmpty(serverPaths)
+            || !serverPaths[0].fsPath
+            || !this.isValidServerPath(serverPaths[0].fsPath)) {
+            vscode.window.showErrorMessage("Selected Payara Server path is invalid.");
+        }
+        state.path = serverPaths[0].fsPath;
+        return (input: ui.MultiStepInput) => this.serverName(input, state, callback);
+    }
+
+    private async serverName(input: ui.MultiStepInput, state: Partial<State>, callback: (n: Partial<State>) => any) {
+        const title = 'Register Payara Server';
+        let serverPath: string = state.path ? state.path : '';
+        let defaultServerName: string = path.basename(serverPath);
+        let serverName = await input.showInputBox({
+            title: title,
+            step: 2,
+            totalSteps: 3,
+            value: state.name || defaultServerName,
+            prompt: 'Enter a unique name for the server',
+            placeHolder: 'Payara Server name',
+            validate: name => this.validateServerName(name, this.instanceProvider),
+            shouldResume: this.shouldResume
+        });
+
+        state.name = serverName ? serverName : defaultServerName;
+        return (input: ui.MultiStepInput) => this.selectDomain(input, state, callback);
+    }
+
+    private async selectDomain(input: ui.MultiStepInput, state: Partial<State>, callback: (n: Partial<State>) => any) {
+        if (!state.path) {
+            return;
+        }
+        let domainsDir: Array<string> = fse.readdirSync(
+            path.join(state.path, 'glassfish', 'domains')
+        );
+        state.domains = domainsDir.map(label => ({ label }));
+
+        const createDomainButton = new MyButton({
+            dark: Uri.file(this.context.asAbsolutePath('resources/theme/dark/add.svg')),
+            light: Uri.file(this.context.asAbsolutePath('resources/theme/light/add.svg')),
+        }, 'Create new Payara Server Domain');
+        const pick = await input.showQuickPick({
+            title: 'Register Payara Server',
+            step: 3,
+            totalSteps: 3,
+            placeholder: 'Select an existing domain.',
+            items: state.domains ? state.domains : [],
+            activeItem: typeof state.domainName !== 'string' ? state.domainName : undefined,
+            buttons: [createDomainButton],
+            shouldResume: this.shouldResume
+        });
+        if (pick instanceof ui.MyButton) {
+            return (input: ui.MultiStepInput) => this.domainRegistration(input, state, domainsDir, callback);
+        }
+
+        state.domainName = pick.label;
+        callback(state);
+    }
+
+    private async validateServerName(name: string, instanceProvider: PayaraInstanceProvider): Promise<string | undefined> {
+        if (_.isEmpty(name)) {
+            return 'Server name cannot be empty';
+        } else if (instanceProvider.getServerByName(name)) {
+            return 'Payar Server already exist with the given name, please re-enter';
+        }
+        return undefined;
+    }
+
+    private async validateDomainName(name: string, existingDomainsDir: Array<string>): Promise<string | undefined> {
+        if (_.isEmpty(name)) {
+            return 'Domain name cannot be empty.';
+        } else if (!/[a-zA-Z0-9_-]+$/.test(name)) {
+            return 'Please enter the valid Domain name.';
+        } else if (existingDomainsDir.indexOf(name) > -1) {
+            return 'Domain already exist, please enter the unique name.';
+        }
+        return undefined;
+    }
+
+    private async validateUserName(name: string): Promise<string | undefined> {
+        if (_.isEmpty(name)) {
+            return 'Username cannot be empty.';
+        }
+        return undefined;
+    }
+
+    private async validatePort(port: string): Promise<string | undefined> {
+        if (!isPort.default(port)) {
+            return 'Please enter the valid port number.';
+        }
+        return undefined;
+    }
+
+    private async domainRegistration(input: ui.MultiStepInput, state: Partial<State>, existingDomainsDir: Array<string>, callback: (n: Partial<State>) => any) {
+        let step: number = 4;
+        let totalSteps: number = 6;
+        let serverPath: string = state.path ? state.path : '';
+        let defaultServerName: string = path.basename(serverPath);
+        let domainName = await input.showInputBox({
+            title: 'Domain name',
+            step: step,
+            totalSteps: totalSteps,
+            value: '',
+            prompt: 'Enter the new domain name',
+            placeHolder: 'Payara Server domain name',
+            validate: value => this.validateDomainName(value, existingDomainsDir),
+            shouldResume: this.shouldResume
+        });
+
+        state.domainName = domainName;
+        state.newDomain = true;
+
+        let decision = await input.showQuickPick({
+            title: 'Use Default ports?',
+            step: ++step,
+            totalSteps: totalSteps,
+            placeholder: 'Default admin port (4848) and http port (8080)',
+            items: [{ label: 'Yes' }, { label: 'No' }],
+            activeItem: { label: 'Yes' },
+            shouldResume: this.shouldResume
+        });
+        if (decision.label === 'No') {
+            totalSteps += 2;
+            let adminPort = await input.showInputBox({
+                title: 'Admin Port',
+                step: ++step,
+                totalSteps: totalSteps,
+                value: '4848',
+                prompt: 'Enter the admin port',
+                placeHolder: 'Enter the admin port 4848',
+                validate: value => this.validatePort(value),
+                shouldResume: this.shouldResume
+            });
+            let httpPort = await input.showInputBox({
+                title: 'Http Port',
+                step: ++step,
+                totalSteps: totalSteps,
+                value: '8080',
+                prompt: 'Enter the http port',
+                placeHolder: 'Enter the http port 8080',
+                validate: value => this.validatePort(value),
+                shouldResume: this.shouldResume
+            });
+            state.adminPort = adminPort;
+            state.httpPort = httpPort;
+        }
+
+        decision = await input.showQuickPick({
+            title: 'Use Default credentials?',
+            step: ++step,
+            totalSteps: totalSteps,
+            placeholder: 'Default username (admin) and password (empty)',
+            items: [{ label: 'Yes' }, { label: 'No' }],
+            activeItem: { label: 'Yes' },
+            shouldResume: this.shouldResume
+        });
+        if (decision.label === 'Yes') {
+            callback(state);
+        } else {
+            totalSteps += 2;
+            state.username = await input.showInputBox({
+                title: 'Username',
+                step: ++step,
+                totalSteps: totalSteps,
+                value: 'admin',
+                prompt: 'Enter the username',
+                placeHolder: 'Enter the username e.g admin',
+                validate: (value: string) => this.validateUserName(value),
+                shouldResume: this.shouldResume
+            });
+            const passwordBox = vscode.window.createInputBox();
+            passwordBox.title = 'Password';
+            passwordBox.step = ++step;
+            passwordBox.totalSteps = totalSteps;
+            passwordBox.value = '';
+            passwordBox.prompt = 'Enter the password';
+            passwordBox.placeholder = 'Enter the password';
+            passwordBox.password = true;
+            passwordBox.show();
+            passwordBox.onDidAccept(async () => {
+                state.password = passwordBox.value;
+                callback(state);
+            });
+        }
+    }
+
+    private isValidServerPath(serverPath: string): boolean {
+        const payaraApiExists: boolean = fse.pathExistsSync(path.join(serverPath, 'glassfish', 'bin', 'asadmin'));
+        const asadminFileExists: boolean = fse.pathExistsSync(path.join(serverPath, 'bin', 'asadmin'));
+        return payaraApiExists && asadminFileExists;
+    }
+
     public async startServer(payaraServer: PayaraServerInstance, debug: boolean): Promise<void> {
-        if(!payaraServer.isStopped()) {
+        if (!payaraServer.isStopped()) {
             vscode.window.showErrorMessage('Payara Server instance already running.');
             return;
         }
@@ -119,7 +455,7 @@ export class PayaraInstanceController {
     }
 
     public async restartServer(payaraServer: PayaraServerInstance): Promise<void> {
-        if(payaraServer.isStopped()) {
+        if (payaraServer.isStopped()) {
             vscode.window.showErrorMessage('Payara Server instance not running.');
             return;
         }
@@ -154,7 +490,7 @@ export class PayaraInstanceController {
     }
 
     public async stopServer(payaraServer: PayaraServerInstance): Promise<void> {
-        if(payaraServer.isStopped()) {
+        if (payaraServer.isStopped()) {
             vscode.window.showErrorMessage('Payara Server instance not running.');
             return;
         }
@@ -176,7 +512,7 @@ export class PayaraInstanceController {
                 value: payaraServer.getName(),
                 prompt: 'Enter a unique name for the server',
                 placeHolder: 'Payara Server name',
-                validateInput: name => this.validateName(name, this.instanceProvider)
+                validateInput: name => this.validateServerName(name, this.instanceProvider)
             }).then(newName => {
                 if (newName) {
                     payaraServer.setName(newName);
@@ -213,92 +549,6 @@ export class PayaraInstanceController {
         vscode.commands.executeCommand('payara.server.refresh');
     }
 
-    private async selectServer(input: ui.MultiStepInput, state: Partial<State>, callback: (n: PayaraServerInstance) => any) {
-
-        const fileUris = await vscode.window.showOpenDialog({
-            defaultUri: vscode.workspace.rootPath ? vscode.Uri.file(vscode.workspace.rootPath) : undefined,
-            canSelectFiles: false,
-            canSelectFolders: true,
-            canSelectMany: false,
-            openLabel: 'Select Payara Server'
-        });
-        const serverPaths: vscode.Uri[] = fileUris ? fileUris : [] as vscode.Uri[];
-        if (_.isEmpty(serverPaths)
-            || !serverPaths[0].fsPath
-            || !this.isValidServerPath(serverPaths[0].fsPath)) {
-            vscode.window.showErrorMessage("Selected Payara Server path is invalid.");
-        }
-        let serverPath: string = serverPaths[0].fsPath;
-        let domainsDir: string = path.join(serverPath, 'glassfish', 'domains');
-        const domains: QuickPickItem[] = fse.readdirSync(domainsDir).map(label => ({ label }));
-
-        state.path = serverPath;
-        state.domains = domains;
-        return (input: ui.MultiStepInput) => this.selectDomain(input, state, callback);
-    }
-
-    async selectDomain(input: ui.MultiStepInput, state: Partial<State>, callback: (n: PayaraServerInstance) => any) {
-        const title = 'Register Payara Server';
-        const pick = await input.showQuickPick({
-            title,
-            step: 2,
-            totalSteps: 3,
-            placeholder: 'Select an existing domain.',
-            items: state.domains ? state.domains : [],
-            activeItem: typeof state.domain !== 'string' ? state.domain : undefined,
-            // buttons: [createDomainButton],
-            shouldResume: this.shouldResume
-        });
-        if (pick instanceof ui.MyButton) {
-            return (input: ui.MultiStepInput) => this.createDomain(input, state, callback);
-        }
-
-        state.domain = pick.label;
-        return (input: ui.MultiStepInput) => this.serverName(input, state, callback);
-    }
-
-    async serverName(input: ui.MultiStepInput, state: Partial<State>, callback: (n: PayaraServerInstance) => any) {
-        const title = 'Register Payara Server';
-        let serverPath: string = state.path ? state.path : '';
-        let defaultServerName: string = path.basename(serverPath);
-        state.name = await input.showInputBox({
-            title: title,
-            step: 3,
-            totalSteps: 3,
-            value: state.name || defaultServerName,
-            prompt: 'Enter a unique name for the server',
-            placeHolder: 'Payara Server name',
-            validate: name => this.validateName(name, this.instanceProvider),
-            shouldResume: this.shouldResume
-        });
-
-        let serverName: string = state.name ? state.name : defaultServerName;
-        let domainName: string = state.domain ? state.domain : 'domain1';
-        let payaraServerInstance: PayaraServerInstance = new PayaraServerInstance(serverName, serverPath, domainName);
-        callback(payaraServerInstance);
-    }
-
-    async validateName(name: string, instanceProvider: PayaraInstanceProvider): Promise<string | undefined> {
-        if (_.isEmpty(name)) {
-            return 'Server name cannot be empty';
-        } else if (instanceProvider.getServerByName(name)) {
-            return 'Payar Server already exist with the given name, please re-enter';
-        }
-        return undefined;
-    }
-
-    async createDomain(input: ui.MultiStepInput, state: Partial<State>, callback: (n: PayaraServerInstance) => any) {
-        const title = 'Register Payara Server';
-        // state.domain = await input.showInputBox({  });
-        return (input: ui.MultiStepInput) => this.serverName(input, state, callback);
-    }
-
-    isValidServerPath(serverPath: string): boolean {
-        const payaraApiExists: boolean = fse.pathExistsSync(path.join(serverPath, 'glassfish', 'bin', 'asadmin'));
-        const asadminFileExists: boolean = fse.pathExistsSync(path.join(serverPath, 'bin', 'asadmin'));
-        return payaraApiExists && asadminFileExists;
-    }
-
     async shouldResume(): Promise<boolean> {
         return new Promise<boolean>((resolve, reject) => {
         });
@@ -312,6 +562,11 @@ interface State {
     totalSteps: number;
     path: string;
     domains: QuickPickItem[];
-    domain: string;
+    domainName: string;
+    newDomain: boolean;
+    adminPort: string;
+    httpPort: string;
+    username: string;
+    password: string;
     name: string;
 }

--- a/src/main/fish/payara/server/PayaraInstanceController.ts
+++ b/src/main/fish/payara/server/PayaraInstanceController.ts
@@ -310,7 +310,7 @@ export class PayaraInstanceController {
 
     private async validatePort(port: string): Promise<string | undefined> {
         if (!isPort.default(port)) {
-            return 'Please enter the valid port number.';
+            return 'Please enter a valid port number.';
         }
         return undefined;
     }

--- a/src/main/fish/payara/server/PayaraInstanceController.ts
+++ b/src/main/fish/payara/server/PayaraInstanceController.ts
@@ -285,7 +285,7 @@ export class PayaraInstanceController {
         if (_.isEmpty(name)) {
             return 'Server name cannot be empty';
         } else if (instanceProvider.getServerByName(name)) {
-            return 'Payar Server already exist with the given name, please re-enter';
+            return 'Payara Server already exist with the given name, please re-enter';
         }
         return undefined;
     }

--- a/src/main/fish/payara/server/PayaraInstanceController.ts
+++ b/src/main/fish/payara/server/PayaraInstanceController.ts
@@ -157,12 +157,6 @@ export class PayaraInstanceController {
         args.push("-jar");
         args.push(path.join(serverPath, "glassfish", "modules", "admin-cli.jar"));
         args.push("create-domain");
-        args.push("--domaindir");
-        args.push(path.join(serverPath, "glassfish", "domains"));
-        args.push("--adminport");
-        args.push(adminPort);
-        args.push("--instanceport");
-        args.push(instancePort);
         args.push("--user");
         args.push(username);
         if (password === '') {
@@ -172,6 +166,12 @@ export class PayaraInstanceController {
             args.push("--passwordfile");
             args.push(passwordFile.name);
         }
+        args.push("--domaindir");
+        args.push(path.join(serverPath, "glassfish", "domains"));
+        args.push("--adminport");
+        args.push(adminPort);
+        args.push("--instanceport");
+        args.push(instancePort);
         args.push(domainName);
         let process: ChildProcess = cp.spawn(javaVmExe, args, { cwd: serverPath });
         if (process.pid) {

--- a/src/main/fish/payara/server/PayaraInstanceController.ts
+++ b/src/main/fish/payara/server/PayaraInstanceController.ts
@@ -296,7 +296,7 @@ export class PayaraInstanceController {
         } else if (!/[a-zA-Z0-9_-]+$/.test(name)) {
             return 'Please enter the valid Domain name.';
         } else if (existingDomainsDir.indexOf(name) > -1) {
-            return 'Domain already exist, please enter the unique name.';
+            return 'Domain already exist, please enter a unique name.';
         }
         return undefined;
     }


### PR DESCRIPTION
# Description
This is a feature providing interface from VSCode to create the new Payara Server Domain.

# Test

- Install Node and Yarn
- Open a terminal and run `yarn install`  to install all dependencies for the project.
- Run `code` command from the terminal to open the project in VS Code.
- Press `F5` from Code to run the project which will start another instance of Code with an installed plugin.
- Press `Ctrl + Shift + P` and search for `Add Payara Server` option.
![GlassFish-Server-VSCode-Domain](https://user-images.githubusercontent.com/15934072/73634308-f0ef5480-4686-11ea-90f8-daf30ed17776.gif)
