### PR TITLE
ECOSYS-115 rest-endpoint api fails on duplicate data listener

### DIFF
--- a/package.json
+++ b/package.json
@@ -371,7 +371,7 @@
 		"@types/lodash": "^4.14.149",
 		"@types/mocha": "^5.2.7",
 		"@types/node": "^12.11.7",
-		"@types/vscode": "^1.40.0",
+		"@types/vscode": "^1.22.0",
 		"glob": "^7.1.5",
 		"mocha": "^6.2.2",
 		"os": "^0.1.1",

--- a/src/main/fish/payara/server/PayaraInstanceController.ts
+++ b/src/main/fish/payara/server/PayaraInstanceController.ts
@@ -510,36 +510,36 @@ export class PayaraInstanceController {
         let endpoints: RestEndpoints = new RestEndpoints(payaraServer);
         let query: string = '?debug=' + debug;
         endpoints.invoke("restart-domain", async (res) => {
-                payaraServer.connectOutput();
-                payaraServer.setDebug(debug);
-                payaraServer.setState(InstanceState.RESTARTING);
-                this.refreshServerList();
-                payaraServer.getOutputChannel().show(false);
-                payaraServer.checkAliveStatusUsingRest(
-                    async () => {
-                        payaraServer.setStarted(true);
-                        this.refreshServerList();
-                        payaraServer.connectOutput();
-                        if (callback) {
-                            callback(true);
-                        }
-                    },
-                    async (message?: string) => {
-                        payaraServer.disconnectOutput();
-                        payaraServer.setStarted(false);
-                        this.refreshServerList();
-                        if (callback) {
-                            callback(false);
-                        }
-                         vscode.window.showErrorMessage('Unable to restart the Payara Server. ' + message);
+            payaraServer.connectOutput();
+            payaraServer.setDebug(debug);
+            payaraServer.setState(InstanceState.RESTARTING);
+            this.refreshServerList();
+            payaraServer.getOutputChannel().show(false);
+            payaraServer.checkAliveStatusUsingRest(
+                async () => {
+                    payaraServer.setStarted(true);
+                    this.refreshServerList();
+                    payaraServer.connectOutput();
+                    if (callback) {
+                        callback(true);
                     }
-                );
-                payaraServer.checkAliveStatusUsingJPS(
-                    async () => {
-                        payaraServer.connectOutput();
+                },
+                async (message?: string) => {
+                    payaraServer.disconnectOutput();
+                    payaraServer.setStarted(false);
+                    this.refreshServerList();
+                    if (callback) {
+                        callback(false);
                     }
-                );
-            },
+                    vscode.window.showErrorMessage('Unable to restart the Payara Server. ' + message);
+                }
+            );
+            payaraServer.checkAliveStatusUsingJPS(
+                async () => {
+                    payaraServer.connectOutput();
+                }
+            );
+        },
             (res, message) => vscode.window.showErrorMessage('Unable to restart the Payara Server. ' + message)
         );
     }
@@ -617,17 +617,17 @@ export class PayaraInstanceController {
             return true;
         };
         let items: QuickPickItem[] = [];
-        let activeItem: QuickPickItem | undefined  = undefined;
+        let activeItem: QuickPickItem | undefined = undefined;
         let javaHome: string | undefined = payaraServer.getJDKHome();
         let defaultJavaHome = JDKVersion.getDefaultJDKHome();
-        if(javaHome) {
-            activeItem = { label: javaHome};
-            items.push({ label: javaHome});
+        if (javaHome) {
+            activeItem = { label: javaHome };
+            items.push({ label: javaHome });
         }
-        if(defaultJavaHome && defaultJavaHome !== javaHome) {
-            let item = {label: defaultJavaHome};
+        if (defaultJavaHome && defaultJavaHome !== javaHome) {
+            let item = { label: defaultJavaHome };
             items.push(item);
-            if(!activeItem) {
+            if (!activeItem) {
                 activeItem = item;
             }
         }
@@ -756,10 +756,8 @@ export class PayaraInstanceController {
         let query: string = '?name=' + encodeURIComponent(application.name);
         endpoints.invoke("undeploy" + query, async response => {
             if (response.statusCode === 200) {
-                response.on('data', data => {
-                    payaraServer.removeApplication(application);
-                    controller.refreshServerList();
-                });
+                payaraServer.removeApplication(application);
+                controller.refreshServerList();
             }
         });
     }
@@ -771,10 +769,8 @@ export class PayaraInstanceController {
         let query: string = '?DEFAULT=' + encodeURIComponent(application.name);
         endpoints.invoke("enable" + query, async response => {
             if (response.statusCode === 200) {
-                response.on('data', data => {
-                    application.setEnabled(true);
-                    controller.refreshServerList();
-                });
+                application.setEnabled(true);
+                controller.refreshServerList();
             }
         });
     }
@@ -786,10 +782,8 @@ export class PayaraInstanceController {
         let query: string = '?DEFAULT=' + encodeURIComponent(application.name);
         endpoints.invoke("disable" + query, async response => {
             if (response.statusCode === 200) {
-                response.on('data', data => {
-                    application.setEnabled(false);
-                    controller.refreshServerList();
-                });
+                application.setEnabled(false);
+                controller.refreshServerList();
             }
         });
     }

--- a/src/main/fish/payara/server/PayaraServerInstance.ts
+++ b/src/main/fish/payara/server/PayaraServerInstance.ts
@@ -351,19 +351,14 @@ export class PayaraServerInstance extends vscode.TreeItem implements vscode.Quic
         let payaraServer = this;
         payaraServer.applicationInstances = new Array<ApplicationInstance>();
         let endpoints: RestEndpoints = new RestEndpoints(this);
-        endpoints.invoke("list-applications", async response => {
+        endpoints.invoke("list-applications", async (response, report) => {
             if (response.statusCode === 200) {
-                response.on('data', function (data) {
-                    new xml2js.Parser().parseString(data.toString(),
-                        function (err: any, result: any) {
-                            let message = result['action-report']['message-part'][0];
-                            for (let property of message.property) {
-                                payaraServer.addApplication(
-                                    new ApplicationInstance(payaraServer, property.$.name, property.$.value)
-                                );
-                            }
-                        });
-                });
+                let message = report['message-part'][0];
+                for (let property of message.property) {
+                    payaraServer.addApplication(
+                        new ApplicationInstance(payaraServer, property.$.name, property.$.value)
+                    );
+                }
             }
         });
     }

--- a/src/main/fish/payara/server/endpoints/RestEndpoints.ts
+++ b/src/main/fish/payara/server/endpoints/RestEndpoints.ts
@@ -33,7 +33,7 @@ export class RestEndpoints {
 
     public invoke(
         command: string, 
-        success?: (res: IncomingMessage) => void, 
+        success?: (res: IncomingMessage, report?: any) => void,
         failure?: (res: IncomingMessage, message?: string) => void): ClientRequest {
 
         let callback = (response: IncomingMessage) => {
@@ -44,7 +44,7 @@ export class RestEndpoints {
                             let report = result['action-report'];
                             let exitCode = report.$['exit-code'];
                             if (exitCode === 'SUCCESS' && success) {
-                                success(response);
+                                success(response, report);
                             } else if (failure) {
                                 failure(response, report['message-part'][0].$['message']);
                             } else {


### PR DESCRIPTION
In this PR duplicate `response.on('data')` listener is removed from client calls as it is now part of `RestEndpoints` callback:
````
if (response.statusCode === 200) {	           
                response.on('data', data => {	                
                    .......	
                });	
}
````