### PR TITLE
ECOSYS-132 Prevent opening of duplicate output window in VSCode

### DIFF
--- a/src/main/fish/payara/micro/PayaraMicroInstance.ts
+++ b/src/main/fish/payara/micro/PayaraMicroInstance.ts
@@ -22,6 +22,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import { Uri } from "vscode";
 import { JDKVersion } from "../server/start/JDKVersion";
+import { ProjectOutputWindowProvider } from "../project/ProjectOutputWindowProvider";
 
 export class PayaraMicroInstance extends vscode.TreeItem implements vscode.QuickPickItem {
 
@@ -44,7 +45,7 @@ export class PayaraMicroInstance extends vscode.TreeItem implements vscode.Quick
     constructor(private context: vscode.ExtensionContext, private name: string, private path: Uri) {
         super(name);
         this.label = name;
-        this.outputChannel = vscode.window.createOutputChannel(name);
+        this.outputChannel = ProjectOutputWindowProvider.getInstance().get(name);
         this.setState(InstanceState.STOPPED);
     }
 

--- a/src/main/fish/payara/micro/PayaraMicroInstanceController.ts
+++ b/src/main/fish/payara/micro/PayaraMicroInstanceController.ts
@@ -21,7 +21,7 @@ import { ChildProcess } from 'child_process';
 import * as _ from "lodash";
 import * as open from "open";
 import * as vscode from 'vscode';
-import { DebugConfiguration, OutputChannel } from 'vscode';
+import { DebugConfiguration } from 'vscode';
 import { BuildSupport } from '../project/BuildSupport';
 import { DebugManager } from '../project/DebugManager';
 import { InstanceState, PayaraMicroInstance } from './PayaraMicroInstance';
@@ -29,13 +29,10 @@ import { PayaraMicroInstanceProvider } from './PayaraMicroInstanceProvider';
 
 export class PayaraMicroInstanceController {
 
-    private outputChannel: OutputChannel;
-
     constructor(
         private context: vscode.ExtensionContext,
         private instanceProvider: PayaraMicroInstanceProvider,
         private extensionPath: string) {
-        this.outputChannel = vscode.window.createOutputChannel("payara");
     }
 
     public async startMicro(payaraMicro: PayaraMicroInstance, debug: boolean, callback?: (status: boolean) => any): Promise<void> {

--- a/src/main/fish/payara/project/ApplicationInstance.ts
+++ b/src/main/fish/payara/project/ApplicationInstance.ts
@@ -21,6 +21,7 @@ import * as vscode from "vscode";
 import * as xml2js from "xml2js";
 import { PayaraServerInstance } from '../server/PayaraServerInstance';
 import { RestEndpoints } from "../server/endpoints/RestEndpoints";
+import { ProjectOutputWindowProvider } from "./ProjectOutputWindowProvider";
 
 export class ApplicationInstance extends vscode.TreeItem {
 
@@ -35,7 +36,7 @@ export class ApplicationInstance extends vscode.TreeItem {
         public name: string,
         public appType?: string | null) {
         super(name);
-        this.outputChannel = vscode.window.createOutputChannel(name);
+        this.outputChannel = ProjectOutputWindowProvider.getInstance().get(name);
     }
 
     public setEnabled(status: boolean): void {

--- a/src/main/fish/payara/project/Gradle.ts
+++ b/src/main/fish/payara/project/Gradle.ts
@@ -28,6 +28,7 @@ import { ChildProcess } from 'child_process';
 import { JavaUtils } from '../server/tooling/utils/JavaUtils';
 import { PayaraMicroProject } from '../micro/PayaraMicroProject';
 import { MicroPluginReader } from '../micro/MicroPluginReader';
+import { ProjectOutputWindowProvider } from './ProjectOutputWindowProvider';
 
 export class Gradle implements Build {
 
@@ -56,7 +57,7 @@ export class Gradle implements Build {
         let process: ChildProcess = cp.spawn(gradleExe, ["clean", "build"], { cwd: this.workspaceFolder.uri.fsPath });
 
         if (process.pid) {
-            let outputChannel = vscode.window.createOutputChannel(path.basename(this.workspaceFolder.uri.fsPath));
+            let outputChannel = ProjectOutputWindowProvider.getInstance().get(this.workspaceFolder);
             outputChannel.show(false);
             let logCallback = (data: string | Buffer): void => outputChannel.append(data.toString());
             if (process.stdout !== null) {

--- a/src/main/fish/payara/project/Maven.ts
+++ b/src/main/fish/payara/project/Maven.ts
@@ -30,6 +30,7 @@ import { PayaraMicroProject } from '../micro/PayaraMicroProject';
 import { MicroPluginReader } from '../micro/MicroPluginReader';
 import { PomReader } from './PomReader';
 import { PayaraMicroPlugin } from '../micro/PayaraMicroPlugin';
+import { ProjectOutputWindowProvider } from './ProjectOutputWindowProvider';
 
 export class Maven implements Build {
 
@@ -66,7 +67,7 @@ export class Maven implements Build {
         let process: ChildProcess = cp.spawn(mavenExe, command, { cwd: this.workspaceFolder.uri.fsPath });
 
         if (process.pid) {
-            let outputChannel = vscode.window.createOutputChannel(path.basename(this.workspaceFolder.uri.fsPath));
+            let outputChannel = ProjectOutputWindowProvider.getInstance().get(this.workspaceFolder);
             outputChannel.show(false);
             outputChannel.append("> " + mavenExe + ' ' + command.join(" ") + '\n');
             let logCallback = (data: string | Buffer): void => {
@@ -161,7 +162,7 @@ export class Maven implements Build {
         let process: ChildProcess = cp.spawn(mavenExe, cmdArgs, { cwd: project.targetFolder?.fsPath });
 
         if (process.pid) {
-            let outputChannel = vscode.window.createOutputChannel(`${project.artifactId}`);
+            let outputChannel = ProjectOutputWindowProvider.getInstance().get(`${project.artifactId}`);
             outputChannel.show(false);
             let logCallback = (data: string | Buffer): void => outputChannel.append(data.toString());
             if (process.stdout !== null) {

--- a/src/main/fish/payara/project/ProjectOutputWindowProvider.ts
+++ b/src/main/fish/payara/project/ProjectOutputWindowProvider.ts
@@ -1,0 +1,51 @@
+'use strict';
+
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { WorkspaceFolder, OutputChannel } from 'vscode';
+
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+export class ProjectOutputWindowProvider {
+
+    private static instance: ProjectOutputWindowProvider;
+
+    private outputWindows = new Map<string, OutputChannel>();
+
+    private constructor() {
+    }
+
+    public static getInstance() {
+        if (!ProjectOutputWindowProvider.instance) {
+            ProjectOutputWindowProvider.instance = new ProjectOutputWindowProvider();
+        }
+        return ProjectOutputWindowProvider.instance;
+    }
+
+    public get(key: WorkspaceFolder | string): OutputChannel {
+        let windowName = typeof key === 'string' ? key : path.basename(key.uri.fsPath);
+        let instance = this.outputWindows.get(windowName);
+        if (!instance) {
+            instance =  vscode.window.createOutputChannel(windowName);
+            this.outputWindows.set(windowName, instance);
+        }
+        return instance;
+    }
+
+}

--- a/src/main/fish/payara/server/PayaraInstanceController.ts
+++ b/src/main/fish/payara/server/PayaraInstanceController.ts
@@ -43,16 +43,14 @@ import { JavaUtils } from './tooling/utils/JavaUtils';
 import { ServerUtils } from './tooling/utils/ServerUtils';
 import { DebugManager } from '../project/DebugManager';
 import { BuildSupport } from '../project/BuildSupport';
+import { ProjectOutputWindowProvider } from '../project/ProjectOutputWindowProvider';
 
 export class PayaraInstanceController {
-
-    private outputChannel: OutputChannel;
 
     constructor(
         private context: vscode.ExtensionContext,
         private instanceProvider: PayaraInstanceProvider,
         private extensionPath: string) {
-        this.outputChannel = vscode.window.createOutputChannel("payara");
         this.init();
     }
 
@@ -161,9 +159,10 @@ export class PayaraInstanceController {
         args.push(domainName);
         let process: ChildProcess = cp.spawn(javaVmExe, args, { cwd: serverPath });
         if (process.pid) {
-            this.outputChannel.show(false);
-            this.outputChannel.append('Running the create-domain asadmin command ... \n');
-            let logCallback = (data: string | Buffer): void => this.outputChannel.append(data.toString());
+            let outputChannel = ProjectOutputWindowProvider.getInstance().get(serverName);
+            outputChannel.show(false);
+            outputChannel.append('Running the create-domain asadmin command ... \n');
+            let logCallback = (data: string | Buffer): void => outputChannel.append(data.toString());
             if (process.stdout !== null) {
                 process.stdout.on('data', logCallback);
             }

--- a/src/main/fish/payara/server/PayaraServerInstance.ts
+++ b/src/main/fish/payara/server/PayaraServerInstance.ts
@@ -31,6 +31,7 @@ import { ApplicationInstance } from "../project/ApplicationInstance";
 import { RestEndpoints } from "./endpoints/RestEndpoints";
 import { IncomingMessage } from "http";
 import { ChildProcess } from "child_process";
+import { ProjectOutputWindowProvider } from "../project/ProjectOutputWindowProvider";
 
 export class PayaraServerInstance extends vscode.TreeItem implements vscode.QuickPickItem {
 
@@ -59,7 +60,7 @@ export class PayaraServerInstance extends vscode.TreeItem implements vscode.Quic
     constructor(private name: string, private path: string, private domainName: string) {
         super(name);
         this.label = name;
-        this.outputChannel = vscode.window.createOutputChannel(name);
+        this.outputChannel = ProjectOutputWindowProvider.getInstance().get(name);
     }
 
     public getName(): string {


### PR DESCRIPTION
This is a bug fix. 
VScode API provides only `vscode.window.createOutputChannel` function but no API available to fetch an existing opened window which causes the opening of multiple windows with the same name on performing the Payara Micro (start/stop/reload) or Server action.