### PR TITLE
ECOSYS-154 Application build failing for environment path having space

### DIFF
--- a/src/main/fish/payara/project/DeploymentSupport.ts
+++ b/src/main/fish/payara/project/DeploymentSupport.ts
@@ -46,29 +46,31 @@ export class DeploymentSupport {
         endpoints.invoke("deploy" + query, async (response, report) => {
             if (response.statusCode === 200) {
                 let message = report['message-part'][0];
-                let property = message.property[0].$;
-                if (property.name === 'name') {
-                    let appName = <string>property.value;
-                    let workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(appPath));
+                if (message && message.property) {
+                    let property = message.property[0].$;
+                    if (property.name === 'name') {
+                        let appName = <string>property.value;
+                        let workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(appPath));
 
-                    if (debug && workspaceFolder) {
-                        let debugConfig: DebugConfiguration | undefined;
-                        let debugManager: DebugManager = new DebugManager();
-                        debugConfig = debugManager.getPayaraConfig(workspaceFolder, debugManager.getDefaultServerConfig());
-                        if (vscode.debug.activeDebugSession) {
-                            let session = vscode.debug.activeDebugSession;
-                            if (session.configuration.port !== debugConfig.port
-                                || session.configuration.type !== debugConfig.type) {
+                        if (debug && workspaceFolder) {
+                            let debugConfig: DebugConfiguration | undefined;
+                            let debugManager: DebugManager = new DebugManager();
+                            debugConfig = debugManager.getPayaraConfig(workspaceFolder, debugManager.getDefaultServerConfig());
+                            if (vscode.debug.activeDebugSession) {
+                                let session = vscode.debug.activeDebugSession;
+                                if (session.configuration.port !== debugConfig.port
+                                    || session.configuration.type !== debugConfig.type) {
                                     vscode.debug.startDebugging(workspaceFolder, debugConfig);
+                                }
+                            } else {
+                                vscode.debug.startDebugging(workspaceFolder, debugConfig);
                             }
-                        } else {
-                            vscode.debug.startDebugging(workspaceFolder, debugConfig);
                         }
-                    }
 
-                    support.controller.openApp(new ApplicationInstance(payaraServer, appName));
-                    payaraServer.reloadApplications();
-                    support.controller.refreshServerList();
+                        support.controller.openApp(new ApplicationInstance(payaraServer, appName));
+                        payaraServer.reloadApplications();
+                        support.controller.refreshServerList();
+                    }
                 }
             }
         });

--- a/src/main/fish/payara/server/PayaraServerInstance.ts
+++ b/src/main/fish/payara/server/PayaraServerInstance.ts
@@ -268,7 +268,7 @@ export class PayaraServerInstance extends vscode.TreeItem implements vscode.Quic
             throw new Error("Java Process " + javaProcessExe + " executable for " + this.getName() + " was not found");
         }
 
-        let output: Buffer = cp.execSync(javaProcessExe + ' -mlv');
+        let output: string = cp.execFileSync(javaProcessExe, ['-mlv']);
         let lines: string[] = output.toString().split(/(?:\r\n|\r|\n)/g);
         for (let line of lines) {
             let result: string[] = line.split(" ");
@@ -333,6 +333,7 @@ export class PayaraServerInstance extends vscode.TreeItem implements vscode.Quic
 
     public addApplication(application: ApplicationInstance): void {
         this.applicationInstances.push(application);
+        vscode.commands.executeCommand('payara.server.refresh');
     }
 
     public removeApplication(application: ApplicationInstance): void {
@@ -353,10 +354,12 @@ export class PayaraServerInstance extends vscode.TreeItem implements vscode.Quic
         endpoints.invoke("list-applications", async (response, report) => {
             if (response.statusCode === 200) {
                 let message = report['message-part'][0];
-                for (let property of message.property) {
-                    payaraServer.addApplication(
-                        new ApplicationInstance(payaraServer, property.$.name, property.$.value)
-                    );
+                if (message && message.property) {
+                    for (let property of message.property) {
+                        payaraServer.addApplication(
+                            new ApplicationInstance(payaraServer, property.$.name, property.$.value)
+                        );
+                    }
                 }
             }
         });


### PR DESCRIPTION
Fixes: https://github.com/payara/ecosystem-vscode-plugin/issues/30

To reproduce the issue: 

- Use default Java Home with space char (e.g C:\Program Files\Java\jdk1.8.0_162)
- Start the Payara Server from VSCode and deploy Maven/Gradle application 
- Check the Developer Console from **Help > Toggle Developer Console** for error trace and log.