### PR TITLE
ECOSYS-134 Customize JDK Home of Payara Micro application

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 		"onCommand:payara.micro.reload",
 		"onCommand:payara.micro.stop",
 		"onCommand:payara.micro.bundle",
+		"onCommand:payara.micro.jdk.home",
 		"onView:payaraServerExplorer",
 		"onView:payaraServer",
 		"onView:payaraMicroExplorer",
@@ -242,6 +243,11 @@
 					"light": "resources/theme/light/bundle.svg",
 					"dark": "resources/theme/dark/bundle.svg"
 				}
+			},
+			{
+				"command": "payara.micro.jdk.home",
+				"title": "JDK Home",
+				"category": "Payara"
 			}
 		],
 		"views": {
@@ -399,6 +405,10 @@
 				},
 				{
 					"command": "payara.micro.bundle",
+					"when": "never"
+				},
+				{
+					"command": "payara.micro.jdk.home",
 					"when": "never"
 				}
 			],
@@ -559,6 +569,11 @@
 					"command": "payara.micro.bundle",
 					"when": "viewItem == stoppedPayaraMicro || viewItem == runningPayaraMicro",
 					"group": "payara-micro@4"
+				},
+				{
+					"command": "payara.micro.jdk.home",
+					"when": "viewItem == loadingPayaraMicro || viewItem == runningPayaraMicro || viewItem == stoppedPayaraMicro",
+					"group": "payara-micro@5"
 				}
 			]
 		}

--- a/src/main/extension.ts
+++ b/src/main/extension.ts
@@ -19,7 +19,7 @@
 
 import * as vscode from 'vscode';
 import { PayaraInstanceProvider } from "./fish/payara/server/PayaraInstanceProvider";
-import { PayaraInstanceController } from "./fish/payara/server/PayaraInstanceController";
+import { PayaraServerInstanceController } from "./fish/payara/server/PayaraServerInstanceController";
 import { PayaraServerTreeDataProvider } from "./fish/payara/server/PayaraServerTreeDataProvider";
 import { PayaraMicroProjectGenerator } from './fish/payara/micro/PayaraMicroProjectGenerator';
 import { PayaraMicroTreeDataProvider } from './fish/payara/micro/PayaraMicroTreeDataProvider';
@@ -32,7 +32,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
 	const payaraServerInstanceProvider: PayaraInstanceProvider = new PayaraInstanceProvider(context);
 	const payaraServerTree: PayaraServerTreeDataProvider = new PayaraServerTreeDataProvider(context, payaraServerInstanceProvider);
-	const payaraServerInstanceController: PayaraInstanceController = new PayaraInstanceController(context, payaraServerInstanceProvider, context.extensionPath);
+	const payaraServerInstanceController: PayaraServerInstanceController = new PayaraServerInstanceController(context, payaraServerInstanceProvider, context.extensionPath);
 
 	const payaraMicroInstanceProvider: PayaraMicroInstanceProvider = new PayaraMicroInstanceProvider(context);
 	const payaraMicroTree: PayaraMicroTreeDataProvider = new PayaraMicroTreeDataProvider(context, payaraMicroInstanceProvider);
@@ -241,6 +241,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 		vscode.commands.registerCommand(
 			'payara.micro.bundle',
 			payaraMicro => payaraMicroInstanceController.bundleMicro(payaraMicro)
+		)
+	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			'payara.micro.jdk.home',
+			payaraMicro => payaraMicroInstanceController.updateJDKHome(payaraMicro)
 		)
 	);
 	context.subscriptions.push(

--- a/src/main/fish/payara/common/PayaraInstance.ts
+++ b/src/main/fish/payara/common/PayaraInstance.ts
@@ -1,0 +1,27 @@
+
+'use strict';
+
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+ interface PayaraInstance {
+    
+    getJDKHome(): string | undefined;
+
+    setJDKHome(jdkHome: string): void;
+
+}

--- a/src/main/fish/payara/common/PayaraInstanceController.ts
+++ b/src/main/fish/payara/common/PayaraInstanceController.ts
@@ -1,0 +1,146 @@
+'use strict';
+
+/*
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+import * as _ from "lodash";
+import * as vscode from 'vscode';
+import { workspace } from 'vscode';
+import { JDKVersion } from "../server/start/JDKVersion";
+import { MyButton } from "../../../UI";
+import * as ui from "../../../UI";
+
+export abstract class PayaraInstanceController {
+
+    constructor(
+        public context: vscode.ExtensionContext) {
+    }
+
+    public async updateJDKHome(payaraInstance: PayaraInstance): Promise<void> {
+        let validateInput: (value: string) => any = path => {
+            let errorMessage = 'Invalid JDK Home path.';
+            try {
+                let version = JDKVersion.getJDKVersion(path.trim());
+                if (!version) {
+                    return errorMessage;
+                }
+            } catch (error) {
+                console.error(error.toString());
+                return errorMessage;
+            }
+            return true;
+        };
+        let items: vscode.QuickPickItem[] = [];
+        let activeItem: vscode.QuickPickItem | undefined = undefined;
+        let javaHome: string | undefined = payaraInstance.getJDKHome();
+        if (javaHome) {
+            activeItem = { label: javaHome, detail: 'currently selected' };
+            items.push(activeItem);
+        }
+
+        const config = workspace.getConfiguration();
+        let javaHomeConfig = config.inspect<string>('java.home');
+        if (javaHomeConfig
+            && javaHomeConfig.workspaceValue
+            && !_.isEmpty(javaHomeConfig.workspaceValue)) {
+            let item = { label: javaHomeConfig.workspaceValue, detail: 'workspace settings > java.home' };
+            items.push(item);
+            if (!activeItem) {
+                activeItem = item;
+            }
+        }
+        if (javaHomeConfig
+            && javaHomeConfig.globalValue
+            && !_.isEmpty(javaHomeConfig.globalValue)) {
+            let item = { label: javaHomeConfig.globalValue, detail: 'global settings > java.home' };
+            items.push(item);
+            if (!activeItem) {
+                activeItem = item;
+            }
+        }
+        if (process.env.JDK_HOME) {
+            let item = { label: process.env.JDK_HOME, detail: 'JDK_HOME environment variables' };
+            items.push(item);
+            if (!activeItem) {
+                activeItem = item;
+            }
+        }
+        if (process.env.JAVA_HOME) {
+            let item = { label: process.env.JAVA_HOME, detail: 'JAVA_HOME environment variables' };
+            items.push(item);
+            if (!activeItem) {
+                activeItem = item;
+            }
+        }
+
+
+        ui.MultiStepInput.run(
+            async (input: ui.MultiStepInput) => {
+                let browseJDKButtonLabel = 'Browse the JDK Home...';
+                const browseJDKButton = new MyButton({
+                    dark: vscode.Uri.file(this.context.asAbsolutePath('resources/theme/dark/add.svg')),
+                    light: vscode.Uri.file(this.context.asAbsolutePath('resources/theme/light/add.svg')),
+                }, browseJDKButtonLabel);
+                let pick = await input.showQuickPick({
+                    title: 'JDK Home',
+                    step: 1,
+                    totalSteps: 1,
+                    items: items,
+                    activeItem: activeItem,
+                    placeholder: (javaHome ? javaHome : 'Enter the JDK Home'),
+                    validate: validateInput,
+                    buttons: [browseJDKButton],
+                    shouldResume: this.shouldResume
+                });
+                let value;
+                if (pick instanceof ui.MyButton || pick.label === browseJDKButtonLabel) {
+                    let fileUris = await vscode.window.showOpenDialog({
+                        defaultUri: javaHome ? vscode.Uri.file(javaHome) : (vscode.workspace.rootPath ? vscode.Uri.file(vscode.workspace.rootPath) : undefined),
+                        canSelectFiles: false,
+                        canSelectFolders: true,
+                        canSelectMany: false,
+                        openLabel: 'Select JDK Home'
+                    });
+                    if (!fileUris) {
+                        return;
+                    }
+                    const serverPaths: vscode.Uri[] = fileUris ? fileUris : [] as vscode.Uri[];
+                    if (_.isEmpty(fileUris)
+                        || !fileUris[0].fsPath
+                        || !validateInput(fileUris[0].fsPath)) {
+                        vscode.window.showErrorMessage("Selected JDK Home path is invalid.");
+                        return;
+                    }
+                    value = fileUris[0].fsPath;
+                } else {
+                    value = pick.label;
+                }
+                if (value && (value = value.trim()) !== javaHome) {
+                    payaraInstance.setJDKHome(value);
+                    this.updateConfig();
+                    vscode.window.showInformationMessage('JDK Home [' + value + '] updated successfully.');
+                }
+            });
+    }
+
+    public async shouldResume(): Promise<boolean> {
+        return new Promise<boolean>((resolve, reject) => {
+        });
+    }
+
+    abstract updateConfig(): void;
+}

--- a/src/main/fish/payara/micro/PayaraMicroInstance.ts
+++ b/src/main/fish/payara/micro/PayaraMicroInstance.ts
@@ -19,14 +19,15 @@
 
 import { ChildProcess } from "child_process";
 import * as path from "path";
+import * as _ from "lodash";
 import * as vscode from "vscode";
-import { Uri } from "vscode";
+import { Uri, workspace } from "vscode";
 import { JDKVersion } from "../server/start/JDKVersion";
 import { ProjectOutputWindowProvider } from "../project/ProjectOutputWindowProvider";
 import { BuildSupport } from "../project/BuildSupport";
 import { Build } from "../project/Build";
 
-export class PayaraMicroInstance extends vscode.TreeItem implements vscode.QuickPickItem {
+export class PayaraMicroInstance extends vscode.TreeItem implements vscode.QuickPickItem, PayaraInstance {
 
     public label: string;
 
@@ -35,8 +36,6 @@ export class PayaraMicroInstance extends vscode.TreeItem implements vscode.Quick
     private outputChannel: vscode.OutputChannel;
 
     private state: InstanceState = InstanceState.STOPPED;
-
-    private jdkHome: string | null = null;
 
     private homePage: string | undefined;
 
@@ -53,7 +52,7 @@ export class PayaraMicroInstance extends vscode.TreeItem implements vscode.Quick
         this.label = name;
         this.outputChannel = ProjectOutputWindowProvider.getInstance().get(name);
         this.setState(InstanceState.STOPPED);
-        this.build = BuildSupport.getBuild(this.path);
+        this.build = BuildSupport.getBuild(this, this.path);
     }
 
     public getBuild() {
@@ -73,14 +72,11 @@ export class PayaraMicroInstance extends vscode.TreeItem implements vscode.Quick
     }
 
     public getJDKHome(): string | undefined {
-        if (this.jdkHome === null) {
-            return JDKVersion.getDefaultJDKHome();
-        }
-        return this.jdkHome;
+        return JDKVersion.getDefaultJDKHome();
     }
 
     public setJDKHome(jdkHome: string) {
-        this.jdkHome = jdkHome;
+        workspace.getConfiguration("java").update("home", jdkHome);
     }
 
     public setDebug(debug: boolean): void {
@@ -92,7 +88,7 @@ export class PayaraMicroInstance extends vscode.TreeItem implements vscode.Quick
     }
 
     public isLoading(): boolean {
-        return this.state === InstanceState.LODING;
+        return this.state === InstanceState.LOADING;
     }
 
     public isStarted(): boolean {
@@ -165,6 +161,6 @@ export class PayaraMicroInstance extends vscode.TreeItem implements vscode.Quick
 
 export enum InstanceState {
     RUNNING = "runningPayaraMicro",
-    LODING = "loadingPayaraMicro",
+    LOADING = "loadingPayaraMicro",
     STOPPED = "stoppedPayaraMicro"
 }

--- a/src/main/fish/payara/micro/PayaraMicroInstanceController.ts
+++ b/src/main/fish/payara/micro/PayaraMicroInstanceController.ts
@@ -20,17 +20,19 @@
 import * as _ from "lodash";
 import * as open from "open";
 import * as vscode from 'vscode';
-import { DebugConfiguration } from 'vscode';
+import { workspace, DebugConfiguration } from 'vscode';
 import { DebugManager } from '../project/DebugManager';
 import { InstanceState, PayaraMicroInstance } from './PayaraMicroInstance';
 import { PayaraMicroInstanceProvider } from './PayaraMicroInstanceProvider';
+import { PayaraInstanceController } from "../common/PayaraInstanceController";
 
-export class PayaraMicroInstanceController {
+export class PayaraMicroInstanceController extends PayaraInstanceController {
 
     constructor(
-        private context: vscode.ExtensionContext,
+        context: vscode.ExtensionContext,
         private instanceProvider: PayaraMicroInstanceProvider,
         private extensionPath: string) {
+        super(context);
     }
 
     public async startMicro(payaraMicro: PayaraMicroInstance, debug: boolean, callback?: (status: boolean) => any): Promise<void> {
@@ -47,7 +49,7 @@ export class PayaraMicroInstanceController {
         }
         try {
             payaraMicro.setDebug(debug);
-            await payaraMicro.setState(InstanceState.LODING);
+            await payaraMicro.setState(InstanceState.LOADING);
             let process = payaraMicro.getBuild()
                 .startPayaraMicro(debugConfig,
                     async data => {
@@ -105,7 +107,7 @@ export class PayaraMicroInstanceController {
             return;
         }
         try {
-            await payaraMicro.setState(InstanceState.LODING);
+            await payaraMicro.setState(InstanceState.LOADING);
             let process = payaraMicro
                 .getBuild()
                 .reloadPayaraMicro(
@@ -178,9 +180,7 @@ export class PayaraMicroInstanceController {
         vscode.commands.executeCommand('payara.micro.refresh.all');
     }
 
-    private async shouldResume(): Promise<boolean> {
-        return new Promise<boolean>((resolve, reject) => {
-        });
+    updateConfig(): void {
     }
 
 }

--- a/src/main/fish/payara/micro/PayaraMicroInstanceProvider.ts
+++ b/src/main/fish/payara/micro/PayaraMicroInstanceProvider.ts
@@ -36,7 +36,7 @@ export class PayaraMicroInstanceProvider {
                 try {
                     let instance = this.instances.get(folder.uri.fsPath);
                     if (!instance) {
-                        let build = BuildSupport.getBuild(folder.uri);
+                        let build = BuildSupport.getBuild(null, folder.uri);
                         instance = new PayaraMicroInstance(this.context, build.getBuildReader().getArtifactId(), folder.uri);
                         this.instances.set(folder.uri.fsPath, instance);
                     }

--- a/src/main/fish/payara/micro/PayaraMicroProjectGenerator.ts
+++ b/src/main/fish/payara/micro/PayaraMicroProjectGenerator.ts
@@ -53,7 +53,7 @@ export class PayaraMicroProjectGenerator {
                             name: project.artifactId,
                             index: 0
                         };
-                        new Maven(workspaceFolder)
+                        new Maven(null, workspaceFolder)
                             .generateMicroProject(project, async (projectPath) => {
                                 const CURRENT_WORKSPACE = "Add to current workspace";
                                 const NEW_WORKSPACE = "Open in new window";

--- a/src/main/fish/payara/project/BuildSupport.ts
+++ b/src/main/fish/payara/project/BuildSupport.ts
@@ -25,15 +25,15 @@ import { Gradle } from './Gradle';
 
 export class BuildSupport {
 
-    public static getBuild(uri: Uri): Build {
+    public static getBuild(payaraInstance: PayaraInstance | null, uri: Uri): Build {
         let workspace = vscode.workspace.getWorkspaceFolder(uri);
         if(!workspace) {
             throw new Error("workspace not found for [" + uri.fsPath + "].");
         }
         if(Maven.detect(workspace)){
-            return new Maven(workspace);
+            return new Maven(payaraInstance, workspace);
         } else if(Gradle.detect(workspace)){
-            return new Gradle(workspace);
+            return new Gradle(payaraInstance, workspace);
         } else {
             throw new Error("Project build not supported for [" + uri.fsPath + "].");
         }

--- a/src/main/fish/payara/project/DeploymentSupport.ts
+++ b/src/main/fish/payara/project/DeploymentSupport.ts
@@ -23,18 +23,18 @@ import { PayaraServerInstance } from "../server/PayaraServerInstance";
 import { BuildSupport } from "./BuildSupport";
 import { RestEndpoints } from "../server/endpoints/RestEndpoints";
 import { ApplicationInstance } from "./ApplicationInstance";
-import { PayaraInstanceController } from "../server/PayaraInstanceController";
+import { PayaraServerInstanceController } from "../server/PayaraServerInstanceController";
 import { DebugManager } from "./DebugManager";
 
 export class DeploymentSupport {
 
     constructor(
-        public controller: PayaraInstanceController) {
+        public controller: PayaraServerInstanceController) {
     }
 
     public buildAndDeployApplication(uri: Uri, payaraServer: PayaraServerInstance, debug: boolean) {
         return BuildSupport
-            .getBuild(uri)
+            .getBuild(payaraServer, uri)
             .buildProject(artifact => this.deployApplication(artifact, payaraServer, debug));
     }
 

--- a/src/main/fish/payara/server/PayaraServerInstance.ts
+++ b/src/main/fish/payara/server/PayaraServerInstance.ts
@@ -33,7 +33,7 @@ import { IncomingMessage } from "http";
 import { ChildProcess } from "child_process";
 import { ProjectOutputWindowProvider } from "../project/ProjectOutputWindowProvider";
 
-export class PayaraServerInstance extends vscode.TreeItem implements vscode.QuickPickItem {
+export class PayaraServerInstance extends vscode.TreeItem implements vscode.QuickPickItem, PayaraInstance {
 
     public label: string;
 
@@ -104,10 +104,10 @@ export class PayaraServerInstance extends vscode.TreeItem implements vscode.Quic
     }
 
     public getJDKHome(): string | undefined {
-        if (this.jdkHome === null) {
-            return JDKVersion.getDefaultJDKHome();
+        if (this.jdkHome !== null) {
+            return this.jdkHome;
         }
-        return this.jdkHome;
+        return JDKVersion.getDefaultJDKHome();
     }
 
     public setJDKHome(jdkHome: string) {
@@ -143,7 +143,7 @@ export class PayaraServerInstance extends vscode.TreeItem implements vscode.Quic
     }
 
     public isLoading(): boolean {
-        return this.state === InstanceState.LODING;
+        return this.state === InstanceState.LOADING;
     }
 
     public isRestarting(): boolean {
@@ -371,7 +371,7 @@ export class PayaraServerInstance extends vscode.TreeItem implements vscode.Quic
 
 export enum InstanceState {
     RUNNING = "runningPayara",
-    LODING = "loadingPayara",
+    LOADING = "loadingPayara",
     RESTARTING = "restartingPayara",
     STOPPED = "stoppedPayara"
 }

--- a/src/main/fish/payara/server/start/JDKVersion.ts
+++ b/src/main/fish/payara/server/start/JDKVersion.ts
@@ -20,7 +20,7 @@
  */
 
 import { workspace } from 'vscode';
-
+import * as _ from "lodash";
 import * as fse from "fs-extra";
 import * as cp from 'child_process';
 import { JavaUtils } from '../tooling/utils/JavaUtils';
@@ -246,12 +246,19 @@ export class JDKVersion {
 
     public static getDefaultJDKHome(): string | undefined {
         const config = workspace.getConfiguration();
-        let javaHome: string | undefined = config.get<string>('java.home');
+        let javaHome;
+        let javaHomeConfig = config.inspect<string>('java.home');
+        if (javaHomeConfig && javaHomeConfig.workspaceValue && !_.isEmpty(javaHomeConfig.workspaceValue)) {
+            javaHome = javaHomeConfig.workspaceValue;
+        }
+        if (!javaHome && javaHomeConfig && javaHomeConfig.globalValue && !_.isEmpty(javaHomeConfig.globalValue)) {
+            javaHome = javaHomeConfig.globalValue;
+        }
         if (!javaHome) {
             javaHome = process.env.JDK_HOME;
-            if (!javaHome) {
-                javaHome = process.env.JAVA_HOME;
-            }
+        }
+        if (!javaHome) {
+            javaHome = process.env.JAVA_HOME;
         }
         return javaHome;
     }


### PR DESCRIPTION
Signed-off-by: Gaurav Gupta <gaurav.gupta@payara.fish>

This is a feature to customize JDK home of Payara Micro application:
![image](https://user-images.githubusercontent.com/15934072/84109405-37432e80-aa40-11ea-932a-a934a04b3fc5.png)

Right-click on the Payara Server/Micro and Select `JDK Home` to customize the JDK Home path.
![image](https://user-images.githubusercontent.com/15934072/84109899-6312e400-aa41-11ea-8e4d-9b4ccbc0dafb.png)


**JDK Home Selection priority:**
Payara Server:
1) Payara Server instance config
2) Local Workspace settings.json `jdk.home` property value
3) Global Workspace settings.json `jdk.home` property value
4) `JAVA_HOME` environment variables
5) `JDK_HOME` environment variables


Payara Micro:
1) Local Workspace settings.json `jdk.home` property value
![image](https://user-images.githubusercontent.com/15934072/84110031-abca9d00-aa41-11ea-8ca6-fba75e23771b.png)

2) Global Workspace settings.json `jdk.home` property value
![image](https://user-images.githubusercontent.com/15934072/84110077-c3098a80-aa41-11ea-8e84-6b3ae1a76f78.png)

3) `JAVA_HOME` environment variables
4) `JDK_HOME` environment variables
