### PR TITLE
FISH-489 JPS command invocation failed from the VSCode

### DIFF
--- a/src/main/fish/payara/server/PayaraLocalServerInstance.ts
+++ b/src/main/fish/payara/server/PayaraLocalServerInstance.ts
@@ -119,7 +119,7 @@ export class PayaraLocalServerInstance extends PayaraServerInstance {
             throw new Error("Java Process " + javaProcessExe + " executable for " + this.getName() + " was not found");
         }
 
-        let output: string = cp.execFileSync(javaProcessExe, ['-mlv']);
+        let output: string = cp.execFileSync(javaProcessExe, ['-m', '-l', '-v']);
         let lines: string[] = output.toString().split(/(?:\r\n|\r|\n)/g);
         for (let line of lines) {
             let result: string[] = line.split(" ");


### PR DESCRIPTION
`jps -mlv` command is not supported by AdoptOpenJDK. This issue is fixed in AdoptOpenJDK 11+.

Fixes: https://github.com/payara/ecosystem-vscode-plugin/issues/50