### PR TITLE
FISH-975 Hot Reload Payara Server application from VSCode

### DIFF
--- a/src/main/fish/payara/common/DeployOption.ts
+++ b/src/main/fish/payara/common/DeployOption.ts
@@ -17,13 +17,20 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
+export namespace DeployOption {
 
-export enum DeployOption {
+    export const DEFAULT = 'DEFAULT';
+    export const AUTO_DEPLOY = 'AUTO_DEPLOY';
+    export const HOT_RELOAD = 'HOT_RELOAD';
+    export const DEFAULT_DESC = 'Only manual deployment';
+    export const AUTO_DEPLOY_DESC = 'Auto deploy complete application';
+    export const HOT_RELOAD_DESC = 'Incremental deploy modified source files';
 
-    DEFAULT = "Only manual deployment",
+    export const ALL_OPTIONS: Map<string, string> = new Map([
+        [DEFAULT, DEFAULT_DESC],
+        [AUTO_DEPLOY, AUTO_DEPLOY_DESC],
+        [HOT_RELOAD, HOT_RELOAD_DESC]
+    ]);
 
-    AUTO_DEPLOY = "Auto deploy complete application",
-
-    HOT_RELOAD = "Incremental deploy modified source files"
 
 }

--- a/src/main/fish/payara/common/PayaraInstance.ts
+++ b/src/main/fish/payara/common/PayaraInstance.ts
@@ -1,8 +1,6 @@
 
 'use strict';
 
-import { DeployOption } from "./DeployOption";
-
 /*
  * Copyright (c) 2020-2021 Payara Foundation and/or its affiliates and others.
  * All rights reserved.
@@ -26,8 +24,8 @@ import { DeployOption } from "./DeployOption";
 
     setJDKHome(jdkHome: string): void;
 
-    getDeployOption(): DeployOption;
+    getDeployOption(): string;
 
-    setDeployOption(deployOption: DeployOption): void;
+    setDeployOption(deployOption: string): void;
 
 }

--- a/src/main/fish/payara/common/PayaraInstanceController.ts
+++ b/src/main/fish/payara/common/PayaraInstanceController.ts
@@ -23,8 +23,8 @@ import { workspace } from 'vscode';
 import { JDKVersion } from "../server/start/JDKVersion";
 import { MyButton } from "../../../UI";
 import * as ui from "../../../UI";
-import { DeployOption } from "./DeployOption";
 import { PayaraInstance } from "./PayaraInstance";
+import { DeployOption } from "./DeployOption";
 
 export abstract class PayaraInstanceController {
 
@@ -155,19 +155,18 @@ export abstract class PayaraInstanceController {
         };
         let items: vscode.QuickPickItem[] = [];
         let activeItem: vscode.QuickPickItem | undefined = undefined;
-        let deployOption: DeployOption | undefined = payaraInstance.getDeployOption();
+        let deployOption: string = payaraInstance.getDeployOption();
 
-        for (var key in DeployOption) {
-            let value: DeployOption = DeployOption[key as keyof typeof DeployOption];
+        for (var [key, value] of DeployOption.ALL_OPTIONS) {
             let item;
-            if (deployOption === value) {
+            if (deployOption === key.toString()) {
                 item = {
-                    label: key,
-                    detail: value + ' (currently selected)'
+                    label: this.humanize(key),
+                    detail: value + ' (currently selected)',
                 };
             } else {
                 item = {
-                    label: key,
+                    label: this.humanize(key),
                     detail: value
                 };
             }
@@ -189,9 +188,9 @@ export abstract class PayaraInstanceController {
                     validate: validateInput,
                     shouldResume: this.shouldResume
                 });
-                let value = pick.label;
-                if (value && (value = value.trim()) !== deployOption) {
-                    payaraInstance.setDeployOption(DeployOption[value as keyof typeof DeployOption]);
+                let value = this.toEnum(pick.label);
+                if (value && value !== deployOption?.toString()) {
+                    payaraInstance.setDeployOption(value);
                     this.updateConfig();
                     vscode.window.showInformationMessage('Deployment setting [' + value + '] updated successfully.');
                 }
@@ -201,6 +200,18 @@ export abstract class PayaraInstanceController {
     public async shouldResume(): Promise<boolean> {
         return new Promise<boolean>((resolve, reject) => {
         });
+    }
+
+    public humanize(text: string) {
+        let i, ags = text.split('_');
+        for (i = 0; i < ags.length; i++) {
+            ags[i] = ags[i].charAt(0).toUpperCase() + ags[i].slice(1).toLowerCase();
+        }
+        return ags.join(' ');
+    }
+
+    public toEnum(text: string) {
+        return text.toUpperCase().replace(' ', '_');
     }
 
     abstract updateConfig(): void;

--- a/src/main/fish/payara/micro/PayaraMicroInstance.ts
+++ b/src/main/fish/payara/micro/PayaraMicroInstance.ts
@@ -26,8 +26,8 @@ import { JDKVersion } from "../server/start/JDKVersion";
 import { ProjectOutputWindowProvider } from "../project/ProjectOutputWindowProvider";
 import { BuildSupport } from "../project/BuildSupport";
 import { Build } from "../project/Build";
-import { DeployOption } from "../common/DeployOption";
 import { PayaraInstance } from "../common/PayaraInstance";
+import { DeployOption } from "../common/DeployOption";
 
 export class PayaraMicroInstance extends vscode.TreeItem implements vscode.QuickPickItem, PayaraInstance {
 
@@ -81,11 +81,11 @@ export class PayaraMicroInstance extends vscode.TreeItem implements vscode.Quick
         workspace.getConfiguration("java").update("home", jdkHome);
     }
 
-    public getDeployOption(): DeployOption {
+    public getDeployOption(): string {
         return DeployOption.DEFAULT;
     }
 
-    public setDeployOption(deployOption: DeployOption) {
+    public setDeployOption(deployOption: string) {
         // not supported yet
     }
 

--- a/src/main/fish/payara/micro/PayaraMicroInstanceController.ts
+++ b/src/main/fish/payara/micro/PayaraMicroInstanceController.ts
@@ -21,10 +21,10 @@ import * as _ from "lodash";
 import * as open from "open";
 import * as vscode from 'vscode';
 import { workspace, DebugConfiguration } from 'vscode';
-import { DebugManager } from '../project/DebugManager';
-import { InstanceState, PayaraMicroInstance } from './PayaraMicroInstance';
-import { PayaraMicroInstanceProvider } from './PayaraMicroInstanceProvider';
 import { PayaraInstanceController } from "../common/PayaraInstanceController";
+import { DebugManager } from '../project/DebugManager';
+import { InstanceState, PayaraMicroInstance } from "./PayaraMicroInstance";
+import { PayaraMicroInstanceProvider } from './PayaraMicroInstanceProvider';
 
 export class PayaraMicroInstanceController extends PayaraInstanceController {
 

--- a/src/main/fish/payara/server/PayaraInstanceProvider.ts
+++ b/src/main/fish/payara/server/PayaraInstanceProvider.ts
@@ -52,6 +52,9 @@ export class PayaraInstanceProvider {
                         new PayaraRemoteServerInstance(
                             instance.name, instance.domainName
                         );
+                        if (instance.deployOption) {
+                            payaraServer.setDeployOption(instance.deployOption);
+                        }
                 if (instance.username) {
                     payaraServer.setUsername(instance.username);
                 }

--- a/src/main/fish/payara/server/PayaraLocalServerInstance.ts
+++ b/src/main/fish/payara/server/PayaraLocalServerInstance.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Copyright (c) 2020 Payara Foundation and/or its affiliates and others.
+ * Copyright (c) 2020-2021 Payara Foundation and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -182,7 +182,8 @@ export class PayaraLocalServerInstance extends PayaraServerInstance {
             domainName: this.getDomainName(),
             username: this.getUsername(),
             password: this.getPassword(),
-            jdkHome: this.getJDKHome()
+            jdkHome: this.getJDKHome(),
+            deployOption: this.getDeployOption()
         };
     }
 

--- a/src/main/fish/payara/server/PayaraServerInstance.ts
+++ b/src/main/fish/payara/server/PayaraServerInstance.ts
@@ -26,8 +26,8 @@ import { ApplicationInstance } from "../project/ApplicationInstance";
 import { RestEndpoints } from "./endpoints/RestEndpoints";
 import { IncomingMessage } from "http";
 import { ProjectOutputWindowProvider } from "../project/ProjectOutputWindowProvider";
-import { DeployOption } from "../common/DeployOption";
 import { PayaraInstance } from "../common/PayaraInstance";
+import { DeployOption } from "../common/DeployOption";
 
 export abstract class PayaraServerInstance extends vscode.TreeItem implements vscode.QuickPickItem, PayaraInstance {
 
@@ -47,7 +47,7 @@ export abstract class PayaraServerInstance extends vscode.TreeItem implements vs
 
     private jdkHome: string | null = null;
 
-    private deployOption: DeployOption | null = null;
+    private deployOption: string = DeployOption.DEFAULT;
 
     private outputChannel: vscode.OutputChannel;
 
@@ -128,14 +128,11 @@ export abstract class PayaraServerInstance extends vscode.TreeItem implements vs
         this.jdkHome = jdkHome;
     }
 
-    public getDeployOption(): DeployOption {
-        if (this.deployOption !== null) {
-            return this.deployOption;
-        }
-        return DeployOption.DEFAULT;
+    public getDeployOption(): string {
+        return this.deployOption;
     }
 
-    public setDeployOption(deployOption: DeployOption) {
+    public setDeployOption(deployOption: string) {
         this.deployOption = deployOption;
     }
 

--- a/src/main/fish/payara/server/PayaraServerInstanceController.ts
+++ b/src/main/fish/payara/server/PayaraServerInstanceController.ts
@@ -732,7 +732,10 @@ export class PayaraServerInstanceController extends PayaraInstanceController {
         vscode.commands.executeCommand('payara.server.refresh');
     }
 
-    public deployApp(uri: Uri, debug: boolean, autoDeploy?: boolean, selectedServer?: PayaraServerInstance | undefined) {
+    public deployApp(uri: Uri, debug: boolean,
+        autoDeploy?: boolean, selectedServer?: PayaraServerInstance | undefined,
+        metadataChanged?: boolean, sourcesChanged?: Uri[]) {
+
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
         ProjectOutputWindowProvider.getInstance().updateStatusBar(`Deploying ${workspaceFolder?.name}`);
         let support = new DeploymentSupport(this);
@@ -740,10 +743,10 @@ export class PayaraServerInstanceController extends PayaraInstanceController {
             let deploy = async (status: boolean) => {
                 if (status) {
                     if (uri.fsPath.endsWith('.war') || uri.fsPath.endsWith('.jar')) {
-                        support.deployApplication(uri.fsPath, server, debug, autoDeploy);
+                        support.deployApplication(uri.fsPath, server, debug, autoDeploy, metadataChanged, sourcesChanged);
                     } else {
                         try {
-                            support.buildAndDeployApplication(uri, server, debug, autoDeploy);
+                            support.buildAndDeployApplication(uri, server, debug, autoDeploy, metadataChanged, sourcesChanged);
                         } catch (error) {
                             vscode.window.showErrorMessage(error.message);
                         }


### PR DESCRIPTION
This is a feature to hot deploy application to the Payara Server on saving the source file. To enable this feature, right click on the server > Deployment Settings > Select Hot Reload.

### Depends on
https://github.com/payara/Payara/pull/5132

### Notes for reviewers
- Not able to find efficient way to serialize `DeployOption` `enum` to config file, so converted it to `string` constant.
-  File Delete and Create event listener not working in windows using `vscode.workspace.createFileSystemWatcher('**/*.java')` API, so currently Hot Reload is support for text document save event.

