### PR TITLE
FISH-1524 Fixes Application deployment via Java Extension manager

### DIFF
--- a/src/main/extension.ts
+++ b/src/main/extension.ts
@@ -186,13 +186,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
 			'payara.server.app.deploy',
-			uri => payaraServerInstanceController.deployApp(uri, false)
+			uri => payaraServerInstanceController.deployApp(vscode.Uri.parse(uri.uri), false)
 		)
 	);
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
 			'payara.server.app.debug',
-			uri => payaraServerInstanceController.deployApp(uri, true)
+			uri => payaraServerInstanceController.deployApp(vscode.Uri.parse(uri.uri), true)
 		)
 	);
 	context.subscriptions.push(


### PR DESCRIPTION
This PR fixes the application deployment issue form **Java Projects Explorer** by reconstructing URI instance by parsing the absolute path:

![image](https://user-images.githubusercontent.com/15934072/123039472-d6e71b00-d40f-11eb-9064-bed391c83bfa.png)
