### PR TITLE
FISH-6643: fixing issues to process uri and pom plugins property

### DIFF
--- a/src/main/extension.ts
+++ b/src/main/extension.ts
@@ -186,13 +186,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
 			'payara.server.app.deploy',
-			uri => payaraServerInstanceController.deployApp(vscode.Uri.parse(uri.uri), false)
+			uri => payaraServerInstanceController.deployApp(vscode.Uri.parse(uri), false)
 		)
 	);
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
 			'payara.server.app.debug',
-			uri => payaraServerInstanceController.deployApp(vscode.Uri.parse(uri.uri), true)
+			uri => payaraServerInstanceController.deployApp(vscode.Uri.parse(uri), true)
 		)
 	);
 	context.subscriptions.push(

--- a/src/main/fish/payara/project/MavenMicroPluginReader.ts
+++ b/src/main/fish/payara/project/MavenMicroPluginReader.ts
@@ -82,8 +82,8 @@ export class MavenMicroPluginReader implements MicroPluginReader {
 
     private parseBuild(build: any) {
         if (build
-            && build[0]
-            && build[0].plugins[0]
+            && build[0] 
+            && build[0].hasOwnProperty('plugins')
             && build[0].plugins[0].plugin) {
             for (let plugin of build[0].plugins[0].plugin) {
                 let groupId = plugin.groupId[0];


### PR DESCRIPTION
Fixing issue to process URL when deploying application and improving validation for plugins property into the pom.

Test:
Manual test following steps described here:
[adding-payara-server-to-visual-studio-code](https://blog.payara.fish/adding-payara-server-to-visual-studio-code)
Now the VSCode is not showing any error and the deploy is working as expected

Test Environment:
Windows 11, VSCode 1.73.1, Node JS 16.18.0, Npm 8.192