### PR TITLE
FISH-6474: adding support to migrate to jakarta 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -483,7 +483,7 @@
 				},
 				{
 					"command": "payara.server.app.migrate",
-					"when": "explorerResourceIsFolder == true || resourceLangId == java || resourceFilename == pom.xml || resourceFilename == build.gradle || resourceExtname == .war || resourceExtname == .jar",
+					"when": "explorerResourceIsFolder == true || resourceExtname == .properties || resourceExtname == .mf || resourceExtname == .tag || resourceLangId == tld || resourceExtname == .jsp || resourceLangId == xml || resourceLangId == java || resourceExtname == .war || resourceExtname == .jar || resourceExtname == .ear || resourceExtname == .rar",
 					"group": "run@2"
 				}
 			],

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"onCommand:payara.server.config.open",
 		"onCommand:payara.server.app.deploy",
 		"onCommand:payara.server.app.debug",
+		"onCommand:payara.server.app.migrate",
 		"onCommand:payara.micro.create.project",
 		"onCommand:payara.micro.refresh",
 		"onCommand:payara.micro.refresh.all",
@@ -211,6 +212,11 @@
 					"light": "resources/theme/light/endpoint.svg",
 					"dark": "resources/theme/dark/endpoint.svg"
 				}
+			},
+			{
+				"command": "payara.server.app.migrate",
+				"title" : "Migrate to Jakarta EE 10",
+				"category": "Payara"
 			},
 			{
 				"command": "payara.micro.create.project",
@@ -432,6 +438,10 @@
 					"when": "never"
 				},
 				{
+					"command": "payara.server.app.migrate",
+					"when": "never"
+				},
+				{
 					"command": "payara.micro.start",
 					"when": "never"
 				},
@@ -470,6 +480,11 @@
 					"command": "payara.server.app.debug",
 					"when": "explorerResourceIsFolder == true || resourceLangId == java || resourceFilename == pom.xml || resourceFilename == build.gradle || resourceExtname == .war || resourceExtname == .jar",
 					"group": "run@1"
+				},
+				{
+					"command": "payara.server.app.migrate",
+					"when": "explorerResourceIsFolder == true || resourceLangId == java || resourceFilename == pom.xml || resourceFilename == build.gradle || resourceExtname == .war || resourceExtname == .jar",
+					"group": "run@2"
 				}
 			],
 			"view/item/context": [
@@ -652,6 +667,11 @@
 					"command": "payara.server.app.debug",
 					"when": "view == javaProjectExplorer && viewItem =~ /java:project(?=.*?\\b\\+maven|gradle\\b)(?=.*?\\b\\+uri\\b)/",
 					"group": "java-project@1"
+				},
+				{
+					"command": "payara.server.app.migrate",
+					"when": "view == javaProjectExplorer && viewItem =~ /java:project(?=.*?\\b\\+maven|gradle\\b)(?=.*?\\b\\+uri\\b)/",
+					"group": "java-project@1"
 				}
 			]
 		}
@@ -693,6 +713,7 @@
 		"os": "^0.1.1",
 		"tslint": "^6.1.0",
 		"typescript": "^4.0.3",
-		"vscode-test": "^1.2.2"
+		"vscode-test": "^1.2.2",
+		"vscode-uri": "3.0.6"
 	}
 }

--- a/src/main/extension.ts
+++ b/src/main/extension.ts
@@ -225,6 +225,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 			restEndpoint => payaraServerInstanceController.openRestEndpoint(restEndpoint)
 		)
 	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			'payara.server.app.migrate',
+			uri => payaraServerInstanceController.migrateToJakarta10(uri)
+		)
+	);
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand(

--- a/src/main/fish/payara/server/PayaraServerInstanceController.ts
+++ b/src/main/fish/payara/server/PayaraServerInstanceController.ts
@@ -29,7 +29,8 @@ import { FileResult } from 'tmp';
 import { URL } from 'url';
 import * as isPort from 'validator/lib/isPort';
 import * as vscode from 'vscode';
-import { OpenDialogOptions, OutputChannel, QuickPickItem, Uri, DebugConfiguration } from 'vscode';
+import * as vscodeUri from 'vscode-uri';
+import { OpenDialogOptions, MessageOptions, OutputChannel, QuickPickItem, MessageItem, Uri, DebugConfiguration, WorkspaceFolder} from 'vscode';
 import { ApplicationInstance } from '../project/ApplicationInstance';
 import { DeploymentSupport } from '../project/DeploymentSupport';
 import * as ui from "../../../UI";
@@ -46,6 +47,7 @@ import { RestEndpoint } from '../project/RestEndpoint';
 import { PayaraInstanceController } from '../common/PayaraInstanceController';
 import { PayaraRemoteServerInstance } from './PayaraRemoteServerInstance';
 import { PayaraLocalServerInstance } from './PayaraLocalServerInstance';
+import { Maven } from '../project/Maven';
 
 export class PayaraServerInstanceController extends PayaraInstanceController {
 
@@ -861,6 +863,135 @@ export class PayaraServerInstanceController extends PayaraInstanceController {
 
     updateConfig(): void {
         this.instanceProvider.updateServerConfig();
+    }
+
+    public async migrateToJakarta10(uri: string) {
+        console.log("selected resource:" + vscodeUri.URI.parse(uri).fsPath);
+        
+        if(uri && fs.existsSync(vscodeUri.URI.parse(uri).fsPath) && fs.lstatSync(vscodeUri.URI.parse(uri).fsPath).isDirectory()) {
+            let directorySelected = await vscode.window.showSaveDialog({
+                saveLabel: 'Select folder',
+                title: 'Selecting folder to migrate',
+                defaultUri: (vscode.workspace.rootPath ? vscode.Uri.file(vscode.workspace.rootPath) : undefined)
+            });
+        
+            console.log('Folder selected'+ directorySelected);
+
+            if (!directorySelected) {
+                let options: vscode.MessageOptions = {
+                    modal: true,
+                    detail: 'Please add a valid folder to make the migration to Jakarta 10'
+                };
+                vscode.window.showWarningMessage("Missed folder", options, ...["Ok"]).then((item)=>{
+                    console.log(item);
+                });
+                return;
+            } 
+
+            if(path.parse(directorySelected.path).ext.length > 0) {
+                let options: vscode.MessageOptions = {
+                    modal: true,
+                    detail: 'Please select a valid folder to make the migration to Jakarta 10'
+                };
+                
+                vscode.window.showWarningMessage("Invalid folder", options, ...["Ok"]).then((item)=>{
+                    console.log(item);
+                });
+                return;
+            }
+            
+            let source = vscodeUri.URI.parse(uri).fsPath;
+            let workspaceFolder: vscode.WorkspaceFolder = {
+                uri: (vscode.workspace.rootPath ? vscode.Uri.file(vscode.workspace.rootPath) : undefined),
+                name: "name",
+                index: 0
+            };
+            let mvn = new Maven(null, workspaceFolder);
+            mvn.migrateToJakarta10( async (code: number) => {
+                                            console.log("Code:"+code);
+                                            if(code > 0) {
+                                                vscode.window.showErrorMessage('Error ocurred during execution please check output'); 
+                                            }
+                                        },
+                                    async (error: { message: any; }) => {
+                                        console.log("error");
+                                        vscode.window.showErrorMessage(error.message+':'+' please check output'); 
+                                    }, source, vscodeUri.URI.parse(directorySelected.path).fsPath);
+
+            let options: vscode.MessageOptions = {
+                modal: true,
+                detail: 'After migrating application you should need to apply pom configuration files by hand. This is a restriction for the transformer maven plugin'
+            };
+            
+            vscode.window.showWarningMessage("Information", options, ...["Ok"]).then((item)=>{
+                console.log(item);
+            });
+            
+        } else if (uri && fs.existsSync(vscodeUri.URI.parse(uri).fsPath) && fs.lstatSync(vscodeUri.URI.parse(uri).fsPath).isFile()) {
+            let directorySelected = await vscode.window.showOpenDialog({
+                canSelectFolders: true,
+                canSelectFiles: false,
+                canSelectMany: false,
+                openLabel: 'Select folder',
+                title: 'Selecting folder to migrate file'
+            });
+
+            console.log('Folder selected:'+ directorySelected);
+
+            if (!directorySelected || directorySelected.length < 1) {
+                let options: vscode.MessageOptions = {
+                    modal: true,
+                    detail: 'Please add a valid folder to make the migration to Jakarta 10'
+                };
+                vscode.window.showWarningMessage("Missed folder", options, ...["Ok"]).then((item)=>{
+                    console.log(item);
+                });
+                return;
+            } 
+
+            if(directorySelected && directorySelected[0].fsPath == vscodeUri.URI.parse(path.parse(uri.toString()).dir).fsPath) {
+                let options: vscode.MessageOptions = {
+                    modal: true,
+                    detail: 'Please select a different folder to make the migration to Jakarta 10'
+                };
+                
+                vscode.window.showWarningMessage("Invalid folder", options, ...["Ok"]).then((item)=>{
+                    console.log(item);
+                });
+                return;
+            }
+
+            let source = vscodeUri.URI.parse(uri).fsPath;
+            let workspaceFolder: vscode.WorkspaceFolder = {
+                uri: (vscode.workspace.rootPath ? vscode.Uri.file(vscode.workspace.rootPath) : undefined),
+                name: "name",
+                index: 0
+            };
+            let mvn = new Maven(null, workspaceFolder);
+            mvn.migrateToJakarta10( async (code: number) => {
+                                            console.log("Code:"+code);
+                                            if(code > 0) {
+                                                vscode.window.showErrorMessage('Error ocurred during execution please check output'); 
+                                            }
+                                        },
+                                    async (error: { message: any; }) => {
+                                        console.log("error");
+                                        vscode.window.showErrorMessage(error.message+':'+' please check output'); 
+                                    }, source, directorySelected[0].fsPath);
+        
+            let options: vscode.MessageOptions = {
+                modal: true,
+                detail: 'After migrating application you should need to apply pom configuration files by hand. This is a restriction for the transformer maven plugin'
+            };
+            
+            vscode.window.showWarningMessage("Information", options, ...["Ok"]).then((item)=>{
+                console.log(item);
+            });
+
+        
+        } else {
+            vscode.window.showErrorMessage('Please select a file or folder');
+        }
     }
 
 }

--- a/src/main/fish/payara/server/PayaraServerInstanceController.ts
+++ b/src/main/fish/payara/server/PayaraServerInstanceController.ts
@@ -976,7 +976,7 @@ export class PayaraServerInstanceController extends PayaraInstanceController {
                     modal: true
                 };
                 
-                await vscode.window.showWarningMessage("Do you want to override file on the same folder?", options, ...["No", "Yes"]).then((item)=>{
+                await vscode.window.showWarningMessage("Do you want to override file?", options, ...["No", "Yes"]).then((item)=>{
                     console.log(item);
                     if(item.toString() != 'Yes') {
                         selectedCancelorNo = true;

--- a/src/main/fish/payara/server/PayaraServerInstanceController.ts
+++ b/src/main/fish/payara/server/PayaraServerInstanceController.ts
@@ -887,7 +887,7 @@ export class PayaraServerInstanceController extends PayaraInstanceController {
             if (!directorySelected || directorySelected.length < 1) {
                 let options: vscode.MessageOptions = {
                     modal: true,
-                    detail: 'Please add a valid folder to make the migration to Jakarta 10'
+                    detail: 'Please add a valid folder to make the migration to Jakarta EE 10'
                 };
                 vscode.window.showWarningMessage("Missed folder", options, ...["Ok"]).then((item)=>{
                     console.log(item);
@@ -901,7 +901,7 @@ export class PayaraServerInstanceController extends PayaraInstanceController {
                     modal: true
                 };
                 
-                await vscode.window.showWarningMessage("Do you want to override folder?", options, ...["No", "Yes"]).then((item)=>{
+                await vscode.window.showWarningMessage("Do you want to override folder?", options, ...["Yes"]).then((item)=>{
                     console.log(item);
                     if(item.toString() != 'Yes') {
                         selectedCancelorNo = true;
@@ -937,7 +937,7 @@ export class PayaraServerInstanceController extends PayaraInstanceController {
             //showing dialog with message regarding to make manual changes for the pom configuration files
             let options: vscode.MessageOptions = {
                 modal: true,
-                detail: 'After migrating application you should need to apply pom configuration files by hand. The suggested dependencies for Jakarta 10 are: \n' 
+                detail: 'After migrating application you should need to apply pom configuration files manually. The suggested dependencies for Jakarta EE 10 are: \n' 
                 + PayaraServerTransformPlugin.JAKARTA_10_DEPENDENCY_EE_API + ' \n or \n'+PayaraServerTransformPlugin.JAKARTA_10_DEPENDENCY_WEB_API
             };
             
@@ -963,7 +963,7 @@ export class PayaraServerInstanceController extends PayaraInstanceController {
             if (!directorySelected || directorySelected.length < 1) {
                 let options: vscode.MessageOptions = {
                     modal: true,
-                    detail: 'Please add a valid folder to make the migration to Jakarta 10'
+                    detail: 'Please add a valid folder to make the migration to Jakarta EE 10'
                 };
                 vscode.window.showWarningMessage("Missed folder", options, ...["Ok"]).then((item)=>{
                     console.log(item);
@@ -976,7 +976,7 @@ export class PayaraServerInstanceController extends PayaraInstanceController {
                     modal: true
                 };
                 
-                await vscode.window.showWarningMessage("Do you want to override file?", options, ...["No", "Yes"]).then((item)=>{
+                await vscode.window.showWarningMessage("Do you want to override file?", options, ...["Yes"]).then((item)=>{
                     console.log(item);
                     if(item.toString() != 'Yes') {
                         selectedCancelorNo = true;

--- a/src/main/fish/payara/server/PayaraServerInstanceController.ts
+++ b/src/main/fish/payara/server/PayaraServerInstanceController.ts
@@ -901,7 +901,7 @@ export class PayaraServerInstanceController extends PayaraInstanceController {
                     modal: true
                 };
                 
-                await vscode.window.showWarningMessage("Do you want to override folder?", options, ...["Yes"]).then((item)=>{
+                await vscode.window.showWarningMessage("Are you sure that you want to override all files in this folder?", options, ...["Yes"]).then((item)=>{
                     console.log(item);
                     if(item.toString() != 'Yes') {
                         selectedCancelorNo = true;
@@ -976,7 +976,7 @@ export class PayaraServerInstanceController extends PayaraInstanceController {
                     modal: true
                 };
                 
-                await vscode.window.showWarningMessage("Do you want to override file?", options, ...["Yes"]).then((item)=>{
+                await vscode.window.showWarningMessage("Are you sure that you want to override this file?", options, ...["Yes"]).then((item)=>{
                     console.log(item);
                     if(item.toString() != 'Yes') {
                         selectedCancelorNo = true;

--- a/src/main/fish/payara/server/PayaraServerInstanceController.ts
+++ b/src/main/fish/payara/server/PayaraServerInstanceController.ts
@@ -967,6 +967,8 @@ export class PayaraServerInstanceController extends PayaraInstanceController {
                 name: "name",
                 index: 0
             };
+            
+            let finalNameFile = path.join(directorySelected[0].fsPath, path.parse(vscodeUri.URI.parse(uri).fsPath).base);
             let mvn = new Maven(null, workspaceFolder);
             mvn.migrateToJakarta10( async (code: number) => {
                                             console.log("Code:"+code);
@@ -977,17 +979,7 @@ export class PayaraServerInstanceController extends PayaraInstanceController {
                                     async (error: { message: any; }) => {
                                         console.log("error");
                                         vscode.window.showErrorMessage(error.message+':'+' please check output'); 
-                                    }, source, directorySelected[0].fsPath);
-        
-            let options: vscode.MessageOptions = {
-                modal: true,
-                detail: 'After migrating application you should need to apply pom configuration files by hand. This is a restriction for the transformer maven plugin'
-            };
-            
-            vscode.window.showWarningMessage("Information", options, ...["Ok"]).then((item)=>{
-                console.log(item);
-            });
-
+                                    }, source, finalNameFile);
         
         } else {
             vscode.window.showErrorMessage('Please select a file or folder');

--- a/src/main/fish/payara/server/PayaraServerTransformPlugin.ts
+++ b/src/main/fish/payara/server/PayaraServerTransformPlugin.ts
@@ -23,5 +23,21 @@ export namespace  PayaraServerTransformPlugin {
     export const GROUP_ID = 'fish.payara.transformer';
     export const VERSION = '0.2.10';
     export const RUN_GOAL = 'run';
+    export const JAKARTA_10_DEPENDENCY_EE_API = ` \
+    \n <dependency> \
+    \n \t \t <groupId>jakarta.platform</groupId> \
+    \n \t \t <artifactId>jakarta.jakartaee-api</artifactId> \
+    \n \t \t <version>10.0.0</version> \
+    \n \t \t <scope>provided</scope> \
+    \n</dependency> \
+    \n `;
+    export const JAKARTA_10_DEPENDENCY_WEB_API = ` \
+    \n <dependency> \
+    \n \t \t <groupId>jakarta.platform</groupId> \
+    \n \t \t <artifactId>jakarta.jakartaee-web-api</artifactId> \
+    \n \t \t <version>10.0.0</version> \
+    \n \t \t <scope>provided</scope> \
+    \n </dependency> \ 
+    `;
 
 }

--- a/src/main/fish/payara/server/PayaraServerTransformPlugin.ts
+++ b/src/main/fish/payara/server/PayaraServerTransformPlugin.ts
@@ -21,7 +21,7 @@ export namespace  PayaraServerTransformPlugin {
 
     export const ARTIFACT_ID = 'fish.payara.transformer.maven';
     export const GROUP_ID = 'fish.payara.transformer';
-    export const VERSION = '0.2.10';
+    export const VERSION = '0.2.11';
     export const RUN_GOAL = 'run';
     export const JAKARTA_10_DEPENDENCY_EE_API = ` \
     \n <dependency> \

--- a/src/main/fish/payara/server/PayaraServerTransformPlugin.ts
+++ b/src/main/fish/payara/server/PayaraServerTransformPlugin.ts
@@ -1,0 +1,27 @@
+'use strict';
+
+/*
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+export namespace  PayaraServerTransformPlugin {
+
+    export const ARTIFACT_ID = 'fish.payara.transformer.maven';
+    export const GROUP_ID = 'fish.payara.transformer';
+    export const VERSION = '0.2.10';
+    export const RUN_GOAL = 'run';
+
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,9 @@
 		],
 		"sourceMap": true,
 		"rootDir": "src",
-		"strict": true   /* enable all strict type-checking options */
+		"strict": true,
+		"strictNullChecks": false   /* disable strict mode for null checks*/
+		/* enable all strict type-checking options */
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */


### PR DESCRIPTION
Description:
Changes to add support to migrate application to Jakarta 10

Tested:
On local environment with VSCode IDE

Environment:
Windows 11,  nodejs V16.18.0, npm 8.19.2

Result of tests:

- migrate file to jakarta 10 with different folder 


https://user-images.githubusercontent.com/279375/209240686-8f247feb-636d-4d59-a386-c4a2bb5e4ea4.mp4


- migrate file to jakarta 10 on the same folder (override)

https://user-images.githubusercontent.com/279375/209240696-8d787df8-32ad-4330-93aa-2476a5f59ff0.mp4



- migrate folder to jakarta 10 to different location



https://user-images.githubusercontent.com/279375/209240708-5aec17ec-6395-4375-8069-f88f2051f2e0.mp4


- migrate folder to jakarta 10 on the same folder (override)



https://user-images.githubusercontent.com/279375/209240721-0047f427-4f73-4506-a8a2-e0e4c3d70873.mp4



