### PR TITLE
FISH-7081 VSCode support Payara Server running on Docker

### DIFF
--- a/src/main/fish/payara/server/PayaraInstanceProvider.ts
+++ b/src/main/fish/payara/server/PayaraInstanceProvider.ts
@@ -70,6 +70,11 @@ export class PayaraInstanceProvider {
                         payaraServer.setStarted(true);
                     });
                 } else if (payaraServer instanceof PayaraRemoteServerInstance) {
+                    if(instance.instanceType == "docker") {
+                        payaraServer.setHostPath(instance.hostPath.trim());
+                        payaraServer.setContainerPath(instance.containerPath.trim());
+                    }
+                    payaraServer.setInstanceType(instance.instanceType);
                     payaraServer.setHost(instance.host ? instance.host.trim() : ServerUtils.DEFAULT_HOST);
                     payaraServer.setAdminPort(instance.adminPort ? instance.adminPort : ServerUtils.DEFAULT_ADMIN_PORT);
                     payaraServer.setHttpPort(instance.httpPort ? instance.httpPort : ServerUtils.DEFAULT_HTTP_PORT);

--- a/src/main/fish/payara/server/PayaraRemoteServerInstance.ts
+++ b/src/main/fish/payara/server/PayaraRemoteServerInstance.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Copyright (c) 2020 Payara Foundation and/or its affiliates and others.
+ * Copyright (c) 2020-2023 Payara Foundation and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -34,6 +34,9 @@ export class PayaraRemoteServerInstance extends PayaraServerInstance {
     private target: string = 'server';
     private job = new CronJob('*/3 * * * * *', () => this.showLog());
     private connectionAllowed: boolean = false;
+    private instanceType: string;
+    private hostPath: string;
+    private containerPath: string;
 
     constructor(name: string, domainName: string) {
         super(name, domainName);
@@ -69,6 +72,30 @@ export class PayaraRemoteServerInstance extends PayaraServerInstance {
 
     public setHost(host: string) {
         this.host = host;
+    }
+
+    public getHostPath(): string {
+        return this.hostPath;
+    }
+
+    public setHostPath(hostPath: string) {
+        this.hostPath = hostPath;
+    }
+
+    public getContainerPath(): string {
+        return this.containerPath;
+    }
+
+    public setContainerPath(containerPath: string) {
+        this.containerPath = containerPath;
+    }
+
+    public getInstanceType(): string {
+        return this.instanceType;
+    }
+
+    public setInstanceType(instanceType: string) {
+        this.instanceType = instanceType;
     }
 
     public getAdminPort(): number {
@@ -127,7 +154,10 @@ export class PayaraRemoteServerInstance extends PayaraServerInstance {
             adminPort: this.getAdminPort(),
             domainName: this.getDomainName(),
             username: this.getUsername(),
-            password: this.getPassword()
+            password: this.getPassword(),
+            hostPath: this.getHostPath(),
+            containerPath: this.getContainerPath(),
+            instanceType: this.getInstanceType()
         };
     }
 

--- a/src/main/fish/payara/server/PayaraServerInstanceController.ts
+++ b/src/main/fish/payara/server/PayaraServerInstanceController.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Copyright (c) 2020-2022 Payara Foundation and/or its affiliates and others.
+ * Copyright (c) 2020-2023 Payara Foundation and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -108,6 +108,11 @@ export class PayaraServerInstanceController extends PayaraInstanceController {
                                     this.refreshServerList();
                                 });
                             } else if (payaraServer instanceof PayaraRemoteServerInstance) {
+                                if(state.instanceType == "docker") {
+                                    payaraServer.setHostPath(state.hostPath.trim());
+                                    payaraServer.setContainerPath(state.containerPath.trim());
+                                }
+                                payaraServer.setInstanceType(state.instanceType);
                                 payaraServer.setHost(state.host ? state.host.trim() : ServerUtils.DEFAULT_HOST);
                                 payaraServer.setAdminPort(state.adminPort ? state.adminPort : ServerUtils.DEFAULT_ADMIN_PORT);
                                 payaraServer.setHttpPort(state.httpPort ? state.httpPort : ServerUtils.DEFAULT_HTTP_PORT);
@@ -255,10 +260,64 @@ export class PayaraServerInstanceController extends PayaraInstanceController {
             return (input: ui.MultiStepInput) => this.selectServer(step, totalSteps, input, state, callback);
         } else {
             state.type = 'remote';
-            totalSteps = 6;
-            return (input: ui.MultiStepInput) => this.serverName(step, totalSteps, input, state, callback);
+            totalSteps = 7;
+            return (input: ui.MultiStepInput) => this.selectServerSubType(step, totalSteps, input, state, callback);
         }
 
+    }
+
+    private async selectServerSubType(step: number, totalSteps: number, input: ui.MultiStepInput, state: Partial<State>, callback: (n: Partial<State>) => any) {
+        let _default = { label: 'Default' };
+        let docker = { label: 'Docker' };
+        const pick = await input.showQuickPick({
+            title: 'Select server type',
+            step: ++step,
+            totalSteps: totalSteps,
+            placeholder: 'Select server remote instance type.',
+            items: [_default, docker],
+            activeItem: _default,
+            shouldResume: this.shouldResume
+        });
+
+        if (pick === _default) {
+            state.instanceType = 'default';
+            return (input: ui.MultiStepInput) => this.serverName(step, totalSteps, input, state, callback);
+        } else {
+            state.instanceType = 'docker';
+            totalSteps = 9;
+            return (input: ui.MultiStepInput) => this.hostPath(step, totalSteps, input, state, callback);
+        }
+
+    }
+
+    private async hostPath(step: number, totalSteps: number, input: ui.MultiStepInput, state: Partial<State>, callback: (n: Partial<State>) => any) {
+        const title = 'Register Payara Server';
+        state.hostPath = await input.showInputBox({
+            title: title,
+            step: ++step,
+            totalSteps: totalSteps,
+            value: state.name,
+            prompt: 'Enter a host path',
+            placeHolder: 'Host path',
+            validate: path => this.validatePath(path),
+            shouldResume: this.shouldResume
+        });
+        return (input: ui.MultiStepInput) => this.containerPath(step, totalSteps, input, state, callback);
+    }
+
+    private async containerPath(step: number, totalSteps: number, input: ui.MultiStepInput, state: Partial<State>, callback: (n: Partial<State>) => any) {
+        const title = 'Register Payara Server';
+        state.containerPath = await input.showInputBox({
+            title: title,
+            step: ++step,
+            totalSteps: totalSteps,
+            value: state.name,
+            prompt: 'Enter a container path',
+            placeHolder: 'Container path',
+            validate: path => this.validatePath(path),
+            shouldResume: this.shouldResume
+        });
+        return (input: ui.MultiStepInput) => this.serverName(step, totalSteps, input, state, callback);
     }
 
     private async selectServer(step: number, totalSteps: number, input: ui.MultiStepInput, state: Partial<State>, callback: (n: Partial<State>) => any) {
@@ -415,6 +474,14 @@ export class PayaraServerInstanceController extends PayaraInstanceController {
         }
         return undefined;
     }
+
+    private async validatePath(path: string): Promise<string | undefined> {
+        if (_.isEmpty(path)) {
+            return 'Please enter a valid path.';
+        }
+        return undefined;
+    }
+
 
     private async domainRegistration(step: number, totalSteps: number, input: ui.MultiStepInput, state: Partial<State>, existingDomainsDir: Array<string>, callback: (n: Partial<State>) => any) {
         totalSteps = state.type === 'local' ? 7 : totalSteps;
@@ -1021,10 +1088,13 @@ export class PayaraServerInstanceController extends PayaraInstanceController {
 
 interface State {
     type: string;
+    instanceType: string;
     title: string;
     step: number;
     totalSteps: number;
     path: string;
+    hostPath: string;
+    containerPath: string;
     domains: QuickPickItem[];
     domainName: string;
     newDomain: boolean;


### PR DESCRIPTION
To test Payara Server instance running in docker container:
`docker run -p 8080:8080 -p 4848:4848 -v C:\Users\Gaurav\mavenproject1:/app/documents payara/server-full
`
To add Payara Server to VSCode:
Select Remote server:
![image](https://user-images.githubusercontent.com/15934072/230094231-c9aa20c7-6c02-4f61-bb0e-3d24a00882b5.png)
Select Docker type
![image](https://user-images.githubusercontent.com/15934072/230093640-49f06b70-2df9-4b01-a5dd-0fe1028a3165.png)
Enter Host path details
![image](https://user-images.githubusercontent.com/15934072/230093831-aceb7331-4858-4811-889d-3b4ae5b6c721.png)
Enter Container path details
![image](https://user-images.githubusercontent.com/15934072/230093959-dc48ffb7-f98f-435f-8596-36ab3d91c411.png)
Next Choose the server and domain name, host as localhost or IP of the docker container, and enter admin for username and password.

Now deploy the application to Payara server, and enable Hot Deploy or Auto Deploy to allow deployment on save action.

