### PR TITLE
FISH-1466 Fetch Payara Server Debug Port From 'launch.json'

### DIFF
--- a/src/main/extension.ts
+++ b/src/main/extension.ts
@@ -114,13 +114,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
 			'payara.server.start',
-			payaraServer => payaraServerInstanceController.startServer(payaraServer, false)
+			payaraServer => payaraServerInstanceController.startServer(payaraServer, false, '')
 		)
 	);
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
 			'payara.server.start.debug',
-			payaraServer => payaraServerInstanceController.startServer(payaraServer, true)
+			payaraServer => {
+				const activeEditor = vscode.window.activeTextEditor;
+				var debugPort = activeEditor ? payaraServerInstanceController.readDebugPortFromWorkspace(activeEditor.document.uri) : undefined;
+				payaraServerInstanceController.startServer(payaraServer, true, debugPort);
+		}
 		)
 	);
 	context.subscriptions.push(

--- a/src/main/fish/payara/server/start/StartTask.ts
+++ b/src/main/fish/payara/server/start/StartTask.ts
@@ -34,7 +34,7 @@ import { PayaraLocalServerInstance } from "../PayaraLocalServerInstance";
 
 export class StartTask {
 
-    public startServer(payaraServer: PayaraLocalServerInstance, debug: boolean): ChildProcess {
+    public startServer(payaraServer: PayaraLocalServerInstance, debug: boolean, debugPort: string): ChildProcess {
         let jvmConfigReader: JvmConfigReader = new JvmConfigReader(payaraServer.getDomainXmlPath(), ServerUtils.DAS_NAME);
 
         let javaHome: string | undefined = payaraServer.getJDKHome();
@@ -73,6 +73,9 @@ export class StartTask {
         // in case user specified it by himslef.
         let debugOpt: string | undefined = propMap.get("debug-options");
         if (debug && debugOpt) {
+            if (this.isValidPort(debugPort)) {
+                debugOpt = debugOpt.replace(/address=\d+/, `address=${debugPort}`);
+            }
             optList.push(debugOpt);
         }
 
@@ -93,6 +96,14 @@ export class StartTask {
         }
         let args: string[] = JavaUtils.parseParameters(allArgs);
         return cp.spawn(javaVmExe, args, { cwd: payaraServer.getPath() });
+    }
+
+    private isValidPort(portStr?: string): boolean {
+        if (!portStr) {
+            return false;
+        }
+        const port = parseInt(portStr, 10);
+        return portStr.trim() !== '' && port >= 0 && port <= 65535;
     }
 
     private addJavaAgent(payaraServer: PayaraLocalServerInstance, jvmConfigReader: JvmConfigReader): void {


### PR DESCRIPTION
This PR adds a feature to read the debugger port from launch.json in VSCode overrides port from domain.xml for example :

````
{
    "configurations": [
    {
        "type": "java",
        "name": "Attach to Remote Program",
        "request": "attach",
        "hostName": "localhost",
        "port": "9999"
    }
    ]
}
````
![image](https://user-images.githubusercontent.com/15934072/231363153-e3edc40e-498d-405e-ad4b-bc1cbee7afe5.png)
