### PR TITLE
FISH-7080 VSCode support Payara Server running on WSL

### DIFF
--- a/src/main/fish/payara/project/Build.ts
+++ b/src/main/fish/payara/project/Build.ts
@@ -26,7 +26,7 @@ import { BuildReader } from "./BuildReader";
 
 export interface Build {
 
-    buildProject(remote: boolean, callback: (artifact: string) => any, silent?: boolean): void;
+    buildProject(remote: boolean, type: string, callback: (artifact: string) => any, silent?: boolean): void;
 
     getDefaultHome(): string | undefined;
 

--- a/src/main/fish/payara/project/Gradle.ts
+++ b/src/main/fish/payara/project/Gradle.ts
@@ -51,7 +51,7 @@ export class Gradle implements Build {
         return fs.existsSync(build);
     }
 
-    public buildProject(remote: boolean,
+    public buildProject(remote: boolean, type: string,
         callback: (artifact: string) => any,
         silent?: boolean): ChildProcess {
 
@@ -69,7 +69,7 @@ export class Gradle implements Build {
                     let artifact: string | null = null;
                     for (var i = 0; i < artifacts.length; i++) {
                         var filename = path.join(buildDir, artifacts[i]);
-                        if (remote) {
+                        if (remote && type !== "docker" && type !== "wsl") {
                             if (artifacts[i].endsWith('.war')
                                 || artifacts[i].endsWith('.jar')
                                 || artifacts[i].endsWith('.rar')) {

--- a/src/main/fish/payara/project/MavenMicroPluginReader.ts
+++ b/src/main/fish/payara/project/MavenMicroPluginReader.ts
@@ -78,6 +78,7 @@ export class MavenMicroPluginReader implements MicroPluginReader {
                 }
             );
         }
+
     }
 
     private parseBuild(build: any) {
@@ -87,10 +88,10 @@ export class MavenMicroPluginReader implements MicroPluginReader {
             && build[0].plugins[0]
             && build[0].plugins[0].plugin) {
             for (let plugin of build[0].plugins[0].plugin) {
-                let groupId = plugin.groupId[0];
-                let artifactId = plugin.artifactId[0];
-                if (groupId === PayaraMicroMavenPlugin.GROUP_ID
-                    && artifactId === PayaraMicroMavenPlugin.ARTIFACT_ID) {
+                if (plugin.groupId
+                    && plugin.artifactId
+                    && plugin.groupId[0] === PayaraMicroMavenPlugin.GROUP_ID
+                    && plugin.artifactId[0] === PayaraMicroMavenPlugin.ARTIFACT_ID) {
                     return plugin;
                 }
             }

--- a/src/main/fish/payara/server/PayaraServerInstanceController.ts
+++ b/src/main/fish/payara/server/PayaraServerInstanceController.ts
@@ -269,12 +269,13 @@ export class PayaraServerInstanceController extends PayaraInstanceController {
     private async selectServerSubType(step: number, totalSteps: number, input: ui.MultiStepInput, state: Partial<State>, callback: (n: Partial<State>) => any) {
         let _default = { label: 'Default' };
         let docker = { label: 'Docker' };
+        let wsl = { label: 'WSL' };
         const pick = await input.showQuickPick({
             title: 'Select server type',
             step: ++step,
             totalSteps: totalSteps,
             placeholder: 'Select server remote instance type.',
-            items: [_default, docker],
+            items: [_default, docker, wsl],
             activeItem: _default,
             shouldResume: this.shouldResume
         });
@@ -282,10 +283,13 @@ export class PayaraServerInstanceController extends PayaraInstanceController {
         if (pick === _default) {
             state.instanceType = 'default';
             return (input: ui.MultiStepInput) => this.serverName(step, totalSteps, input, state, callback);
-        } else {
+        } else if (pick === docker) {
             state.instanceType = 'docker';
             totalSteps = 9;
             return (input: ui.MultiStepInput) => this.hostPath(step, totalSteps, input, state, callback);
+        } else {
+            state.instanceType = 'wsl';
+            return (input: ui.MultiStepInput) => this.serverName(step, totalSteps, input, state, callback);
         }
 
     }


### PR DESCRIPTION
This PR adds support for the Payara Server instance running on WSL. Usually, developers can register instances running on WSL as remote servers. However, with this PR, developers can take advantage of new features that allow them to auto-deploy on save action both static (.html) and dynamic (.java) applications to the Payara Server running on WSL.

To test this feature, start the server, set a password for the user, and enable the secure domain:
````
./asadmin start-domain
./asadmin change-admin-password
./asadmin enable-secure-admin
./asadmin restart-domain
````
![image](https://user-images.githubusercontent.com/15934072/228462731-bf650500-d6ed-4cdb-ab12-321da3b36cee.png)

Register the server as a Remote Server with WSL type:

![image](https://user-images.githubusercontent.com/15934072/232028202-f5f1cabe-d448-4cbf-a48d-1f257bafaf4d.png)

Fetch the IP address of WSL instance using the command `hostname -I` and enter it in the host field in VSCode.
