### PR TITLE
FISH-7541 Open the server home and domain directory in Explorer via VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ yarn.lock
 package-lock.json
 *.vsix
 .vscode-test/
+yarn-error.log

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
 		"onCommand:payara.server.console.open",
 		"onCommand:payara.server.log.open",
 		"onCommand:payara.server.config.open",
+		"onCommand:payara.server.domain.open",
+		"onCommand:payara.server.home.open",
 		"onCommand:payara.server.app.deploy",
 		"onCommand:payara.server.app.debug",
 		"onCommand:payara.server.app.migrate",
@@ -172,6 +174,16 @@
 			{
 				"command": "payara.server.config.open",
 				"title": "View Domain Server Config",
+				"category": "Payara"
+			},
+			{
+				"command": "payara.server.domain.open",
+				"title": "Open Domain Directory",
+				"category": "Payara"
+			},
+			{
+				"command": "payara.server.home.open",
+				"title": "Open Server Home Directory",
 				"category": "Payara"
 			},
 			{
@@ -410,6 +422,14 @@
 					"when": "never"
 				},
 				{
+					"command": "payara.server.domain.open",
+					"when": "never"
+				},
+				{
+					"command": "payara.server.home.open",
+					"when": "never"
+				},
+				{
 					"command": "payara.server.app.deploy",
 					"when": "never"
 				},
@@ -579,6 +599,16 @@
 					"group": "view@11"
 				},
 				{
+					"command": "payara.server.domain.open",
+					"when": "viewItem == loadingPayaraLocal || viewItem == runningPayaraLocal || viewItem == stoppedPayaraLocal",
+					"group": "view@12"
+				},
+				{
+					"command": "payara.server.home.open",
+					"when": "viewItem == loadingPayaraLocal || viewItem == runningPayaraLocal || viewItem == stoppedPayaraLocal",
+					"group": "view@13"
+				},
+				{
 					"command": "payara.server.app.undeploy",
 					"when": "viewItem == payara-application",
 					"group": "application@1"
@@ -694,7 +724,7 @@
 		"fs-extra": "^11.1.0",
 		"gradle-to-js": "^2.0.0",
 		"lodash": "^4.17.21",
-		"open": "^9.1.0 ",
+		"open": "^8.4.2 ",
 		"request": "^2.88.0",
 		"tail": "^2.0.3",
 		"tmp": "^0.2.0",
@@ -708,7 +738,7 @@
 		"@types/mocha": "^10.0.0",
 		"@types/node": "^20.3.1",
 		"@types/vscode": "^1.22.0",
-		"glob": "^10.2.7",
+		"glob": "^7.1.7",
 		"mocha": "^10.0.0",
 		"os": "^0.1.1",
 		"tslint": "^6.1.0",

--- a/src/main/extension.ts
+++ b/src/main/extension.ts
@@ -189,6 +189,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	);
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
+			'payara.server.domain.open',
+			payaraServer => payaraServerInstanceController.openDomainDirectory(payaraServer)
+		)
+	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			'payara.server.home.open',
+			payaraServer => payaraServerInstanceController.openServerHomeDirectory(payaraServer)
+		)
+	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
 			'payara.server.app.deploy',
 			uri => payaraServerInstanceController.deployApp(vscode.Uri.parse(uri), false)
 		)

--- a/src/main/fish/payara/server/PayaraServerInstanceController.ts
+++ b/src/main/fish/payara/server/PayaraServerInstanceController.ts
@@ -108,7 +108,7 @@ export class PayaraServerInstanceController extends PayaraInstanceController {
                                     this.refreshServerList();
                                 });
                             } else if (payaraServer instanceof PayaraRemoteServerInstance) {
-                                if(state.instanceType == "docker") {
+                                if (state.instanceType == "docker") {
                                     payaraServer.setHostPath(state.hostPath.trim());
                                     payaraServer.setContainerPath(state.containerPath.trim());
                                 }
@@ -863,10 +863,13 @@ export class PayaraServerInstanceController extends PayaraInstanceController {
 
     public readDebugPortFromWorkspace(uri: Uri) {
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
-        const launchConfig = vscode.workspace.getConfiguration('launch', workspaceFolder.uri);
-        const debugConfigurations = launchConfig.get('configurations') as any[];
-        const debugConfig = debugConfigurations.find(config => config.type === 'java' && config.request === 'attach');
-        return debugConfig && debugConfig.port;
+        if (workspaceFolder) {
+            const launchConfig = vscode.workspace.getConfiguration('launch', workspaceFolder.uri);
+            const debugConfigurations = launchConfig.get('configurations') as any[];
+            const debugConfig = debugConfigurations.find(config => config.type === 'java' && config.request === 'attach');
+            return debugConfig && debugConfig.port;
+        }
+        return undefined;
     }
 
     private selectListedServer(callback: (server: PayaraServerInstance) => any) {

--- a/src/main/fish/payara/server/PayaraServerInstanceController.ts
+++ b/src/main/fish/payara/server/PayaraServerInstanceController.ts
@@ -801,6 +801,16 @@ export class PayaraServerInstanceController extends PayaraInstanceController {
             .then(doc => vscode.window.showTextDocument(doc));
     }
 
+    public async openDomainDirectory(payaraServer: PayaraLocalServerInstance): Promise<void> {
+        let domainDirectory = Uri.file(payaraServer.getDomainPath());
+        vscode.env.openExternal(domainDirectory);
+    }
+
+    public async openServerHomeDirectory(payaraServer: PayaraLocalServerInstance): Promise<void> {
+        let serverHomeDirectory = Uri.file(payaraServer.getServerHome());
+        vscode.env.openExternal(serverHomeDirectory);
+    }
+
     public async refreshServerList(): Promise<void> {
         vscode.commands.executeCommand('payara.server.refresh');
     }

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -11,14 +11,6 @@ export async function run(): Promise<void> {
 	});
 
 	const testsRoot = path.resolve(__dirname, '..');
-
-    // // Add test files to the Mocha instance
-    // const testFiles = await getTestFiles(testsRoot);
-    // testFiles.forEach((file) => {
-    //     mocha.addFile(file);
-    // });
-
-    // Detect test files and add them to Mocha
 	const testFiles = findTestFiles(testsRoot);
     testFiles.forEach((file: string) => {
         mocha.addFile(file);
@@ -39,30 +31,6 @@ export async function run(): Promise<void> {
         console.error('Failed to run tests:', error);
         process.exit(1);
     }
-
-	// return new Promise((c, e) => {
-	// 	glob('**/**.test.js', { cwd: testsRoot }, (err: any, files: string[]) => {
-	// 		if (err) {
-	// 			return e(err);
-	// 		}
-
-	// 		// Add files to the test suite
-	// 		files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
-
-	// 		try {
-	// 			// Run the mocha test
-	// 			mocha.run((failures: number) => {
-	// 				if (failures > 0) {
-	// 					e(new Error(`${failures} tests failed.`));
-	// 				} else {
-	// 					c();
-	// 				}
-	// 			});
-	// 		} catch (err) {
-	// 			e(err);
-	// 		}
-	// 	});
-	// });
 }
 
 function findTestFiles(rootDir: string): string[] {

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -1,8 +1,9 @@
 import * as path from 'path';
 import * as Mocha from 'mocha';
 import * as glob from 'glob';
+import * as fs from 'fs';
 
-export function run(): Promise<void> {
+export async function run(): Promise<void> {
 	// Create the mocha test
 	const mocha = new Mocha({
 		ui: 'tdd',
@@ -11,27 +12,78 @@ export function run(): Promise<void> {
 
 	const testsRoot = path.resolve(__dirname, '..');
 
-	return new Promise((c, e) => {
-		glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
-			if (err) {
-				return e(err);
-			}
+    // // Add test files to the Mocha instance
+    // const testFiles = await getTestFiles(testsRoot);
+    // testFiles.forEach((file) => {
+    //     mocha.addFile(file);
+    // });
 
-			// Add files to the test suite
-			files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
+    // Detect test files and add them to Mocha
+	const testFiles = findTestFiles(testsRoot);
+    testFiles.forEach((file: string) => {
+        mocha.addFile(file);
+    });
 
-			try {
-				// Run the mocha test
-				mocha.run(failures => {
-					if (failures > 0) {
-						e(new Error(`${failures} tests failed.`));
-					} else {
-						c();
-					}
-				});
-			} catch (err) {
-				e(err);
-			}
-		});
-	});
+    // Run the tests
+    try {
+        await new Promise<void>((resolve, reject) => {
+            mocha.run((failures) => {
+                if (failures > 0) {
+                    reject(new Error(`${failures} tests failed.`));
+                } else {
+                    resolve();
+                }
+            });
+        });
+    } catch (error) {
+        console.error('Failed to run tests:', error);
+        process.exit(1);
+    }
+
+	// return new Promise((c, e) => {
+	// 	glob('**/**.test.js', { cwd: testsRoot }, (err: any, files: string[]) => {
+	// 		if (err) {
+	// 			return e(err);
+	// 		}
+
+	// 		// Add files to the test suite
+	// 		files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
+
+	// 		try {
+	// 			// Run the mocha test
+	// 			mocha.run((failures: number) => {
+	// 				if (failures > 0) {
+	// 					e(new Error(`${failures} tests failed.`));
+	// 				} else {
+	// 					c();
+	// 				}
+	// 			});
+	// 		} catch (err) {
+	// 			e(err);
+	// 		}
+	// 	});
+	// });
+}
+
+function findTestFiles(rootDir: string): string[] {
+    const testFiles: string[] = [];
+    const files = fs.readdirSync(rootDir);
+
+    files.forEach((file: string) => {
+        const filePath = path.join(rootDir, file);
+        const stats = fs.statSync(filePath);
+
+        if (stats.isDirectory()) {
+            testFiles.push(...findTestFiles(filePath));
+        } else if (file.endsWith('.test.js')) { // Adjust the file extension if needed
+            testFiles.push(filePath);
+        }
+    });
+
+    return testFiles;
+}
+
+// Run the tests when the script is executed directly
+if (require.main === module) {
+    run();
 }


### PR DESCRIPTION
This PR adds the feature to open the server home and domain directory in Explorer, right-click on the registered server in VSCode, and select the option.
![image](https://github.com/payara/ecosystem-vscode-plugin/assets/15934072/949103f7-4440-4fa6-a97a-50d7d53429bf)
