### PR TITLE
Maven Class FireCommand Method Pass Environment Variables

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,3 +8,4 @@ vsc-extension-quickstart.md
 **/tslint.json
 **/*.map
 **/*.ts
+.devcontainer/

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
 		"Payara Server",
 		"Payara Micro"
 	],
+	"engines": {
+		"vscode": "^1.22.0"
+	},
 	"categories": [
 		"Other"
 	],

--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
 			},
 			{
 				"command": "payara.server.app.migrate",
-				"title" : "Transform to Jakarta EE 10",
+				"title": "Transform to Jakarta EE 10",
 				"category": "Payara"
 			},
 			{

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"Payara Micro"
 	],
 	"engines": {
-		"vscode": "^1.22.0"
+		"vscode": "^1.91.0"
 	},
 	"categories": [
 		"Other"

--- a/package.json
+++ b/package.json
@@ -734,7 +734,7 @@
 		"@types/lodash": "^4.14.155",
 		"@types/mocha": "^10.0.0",
 		"@types/node": "^20.3.1",
-		"@types/vscode": "^1.22.0",
+		"@types/vscode": "^1.91.0",
 		"glob": "^7.1.7",
 		"mocha": "^10.0.0",
 		"os": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
 		"Payara Server",
 		"Payara Micro"
 	],
-	"engines": {
-		"vscode": "^1.22.0"
-	},
 	"categories": [
 		"Other"
 	],

--- a/src/main/fish/payara/micro/PayaraMicroInstance.ts
+++ b/src/main/fish/payara/micro/PayaraMicroInstance.ts
@@ -119,7 +119,7 @@ export class PayaraMicroInstance extends vscode.TreeItem implements vscode.Quick
 
     public async setState(state: InstanceState): Promise<void> {
         this.state = state;
-        this.iconPath = this.context.asAbsolutePath(path.join('resources', this.getIcon()));
+        this.iconPath = this.context.asAbsolutePath(path.join('resources', this.getIcon())) as unknown as vscode.Uri;
         this.contextValue = this.getState();
         this.tooltip = this.getPath().fsPath;
         vscode.commands.executeCommand('payara.micro.refresh', this);

--- a/src/main/fish/payara/micro/PayaraMicroInstance.ts
+++ b/src/main/fish/payara/micro/PayaraMicroInstance.ts
@@ -58,6 +58,12 @@ export class PayaraMicroInstance extends vscode.TreeItem implements vscode.Quick
         this.setState(InstanceState.STOPPED);
         this.build = BuildSupport.getBuild(this, this.path);
     }
+    kind?: vscode.QuickPickItemKind;
+    detail?: string;
+    picked?: boolean;
+    alwaysShow?: boolean;
+    buttons?: readonly vscode.QuickInputButton[];
+    iconPath?: vscode.Uri;
 
     public getBuild() {
         return this.build;

--- a/src/main/fish/payara/project/Maven.ts
+++ b/src/main/fish/payara/project/Maven.ts
@@ -19,6 +19,7 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as ps from 'process';
 import * as cp from 'child_process';
 import * as fs from 'fs';
 import { WorkspaceFolder, Uri, DebugConfiguration, TaskDefinition } from "vscode";
@@ -132,7 +133,7 @@ export class Maven implements Build {
         }
 
         let jdkHome;
-        let env: any = {};
+        let env: any = {...ps.env};
         if (this.payaraInstance && (jdkHome = this.payaraInstance.getJDKHome())) {
             env['JAVA_HOME'] = jdkHome;
         }

--- a/src/main/fish/payara/server/PayaraServerInstance.ts
+++ b/src/main/fish/payara/server/PayaraServerInstance.ts
@@ -60,6 +60,12 @@ export abstract class PayaraServerInstance extends vscode.TreeItem implements vs
         this.label = name;
         this.outputChannel = ProjectOutputWindowProvider.getInstance().get(name);
     }
+    kind?: vscode.QuickPickItemKind;
+    detail?: string;
+    picked?: boolean;
+    alwaysShow?: boolean;
+    buttons?: readonly vscode.QuickInputButton[];
+    iconPath?: vscode.Uri;
 
     abstract getId(): string;
 

--- a/src/main/fish/payara/server/PayaraServerTreeDataProvider.ts
+++ b/src/main/fish/payara/server/PayaraServerTreeDataProvider.ts
@@ -46,7 +46,7 @@ export class PayaraServerTreeDataProvider implements vscode.TreeDataProvider<Tre
     public async getChildren(item?: TreeItem): Promise<TreeItem[]> {
         if (!item) {
             return this.instanceProvider.getServers().map((server: PayaraServerInstance) => {
-                server.iconPath = this.context.asAbsolutePath(path.join('resources', server.getIcon()));
+                server.iconPath = this.context.asAbsolutePath(path.join('resources', server.getIcon())) as unknown as vscode.Uri;
                 server.contextValue = server.getState() + (server instanceof PayaraLocalServerInstance ? "Local" : "Remote");
                 server.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
                 server.label = server.getName();


### PR DESCRIPTION
This pull request started from the need to have environment variables from the system/shell in the child process spawned by the maven class firecommand method. I made a handful of other commits to get the project to compile. I couldn't get the npm test script to run, but that's because I'm developing in a dev container without x server. I packaged the extension, installed it locally, and confirmed the environment variables are available to the child processes as expected.

Reference [Bug Report: VS Code Payara Tools Extension - Payara Micro Instance - Missing Environment Variables #91](https://github.com/payara/ecosystem-support/issues/91)