### PR TITLE
FISH-9778 Fixes conflict property with different datatype in "extends vscode.TreeItem implements vscode.QuickPickItem"

### DIFF
--- a/src/main/fish/payara/micro/PayaraMicroInstance.ts
+++ b/src/main/fish/payara/micro/PayaraMicroInstance.ts
@@ -51,6 +51,8 @@ export class PayaraMicroInstance extends vscode.TreeItem implements vscode.Quick
 
     private build: Build;
 
+    public iconPath?: Uri | vscode.ThemeIcon | { light: Uri; dark: Uri; };
+
     constructor(private context: vscode.ExtensionContext, private name: string, private path: Uri) {
         super(name);
         this.label = name;
@@ -113,7 +115,7 @@ export class PayaraMicroInstance extends vscode.TreeItem implements vscode.Quick
 
     public async setState(state: InstanceState): Promise<void> {
         this.state = state;
-        this.iconPath = this.context.asAbsolutePath(path.join('resources', this.getIcon()));
+        this.iconPath = vscode.Uri.file(this.context.asAbsolutePath(path.join('resources', this.getIcon())));
         this.contextValue = this.getState();
         this.tooltip = this.getPath().fsPath;
         vscode.commands.executeCommand('payara.micro.refresh', this);

--- a/src/main/fish/payara/server/PayaraServerInstance.ts
+++ b/src/main/fish/payara/server/PayaraServerInstance.ts
@@ -28,6 +28,7 @@ import { IncomingMessage } from "http";
 import { ProjectOutputWindowProvider } from "../project/ProjectOutputWindowProvider";
 import { PayaraInstance } from "../common/PayaraInstance";
 import { DeployOption } from "../common/DeployOption";
+import { Uri } from "vscode";
 
 export abstract class PayaraServerInstance extends vscode.TreeItem implements vscode.QuickPickItem, PayaraInstance {
 
@@ -54,6 +55,8 @@ export abstract class PayaraServerInstance extends vscode.TreeItem implements vs
     private applicationInstances: Array<ApplicationInstance> = new Array<ApplicationInstance>();
 
     private versionLabel: string | undefined;
+
+    public iconPath?: Uri | vscode.ThemeIcon | { light: Uri; dark: Uri; };
 
     constructor(private name: string, private domainName: string) {
         super(name);

--- a/src/main/fish/payara/server/PayaraServerTreeDataProvider.ts
+++ b/src/main/fish/payara/server/PayaraServerTreeDataProvider.ts
@@ -46,7 +46,7 @@ export class PayaraServerTreeDataProvider implements vscode.TreeDataProvider<Tre
     public async getChildren(item?: TreeItem): Promise<TreeItem[]> {
         if (!item) {
             return this.instanceProvider.getServers().map((server: PayaraServerInstance) => {
-                server.iconPath = this.context.asAbsolutePath(path.join('resources', server.getIcon()));
+                server.iconPath = vscode.Uri.file(this.context.asAbsolutePath(path.join('resources', server.getIcon())));
                 server.contextValue = server.getState() + (server instanceof PayaraLocalServerInstance ? "Local" : "Remote");
                 server.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
                 server.label = server.getName();
@@ -55,7 +55,7 @@ export class PayaraServerTreeDataProvider implements vscode.TreeDataProvider<Tre
             });
         } else if (item instanceof PayaraServerInstance && item.isStarted()) {
             return item.getApplications().map((application: ApplicationInstance) => {
-                application.iconPath = this.context.asAbsolutePath(path.join('resources', application.getIcon()));
+                application.iconPath = vscode.Uri.file(this.context.asAbsolutePath(path.join('resources', application.getIcon())));
                 application.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
                 application.label = application.name;
                 application.contextValue = "payara-application";
@@ -63,7 +63,7 @@ export class PayaraServerTreeDataProvider implements vscode.TreeDataProvider<Tre
             });
         } else if (item instanceof ApplicationInstance) {
             return item.getRestEndpoints().map((endpoint: RestEndpoint) => {
-                endpoint.iconPath = this.context.asAbsolutePath(path.join('resources', 'rest-endpoint.svg'));
+                endpoint.iconPath = vscode.Uri.file(this.context.asAbsolutePath(path.join('resources', 'rest-endpoint.svg')));
                 endpoint.label = endpoint.httpMethod + " " + endpoint.endpoint;
                 endpoint.contextValue = "application-rest-endpoint";
                 return endpoint;


### PR DESCRIPTION
The compiler error is due to a type mismatch in the `iconPath` property between the `QuickPickItem` class and `TreeItem` interface. In this PR, the property is overridden, which fixes the issue."