### PR TITLE
FISH-9715 Payara Micro 7 project support

### DIFF
--- a/src/main/fish/payara/project/Maven.ts
+++ b/src/main/fish/payara/project/Maven.ts
@@ -278,7 +278,7 @@ export class Maven implements Build {
             throw new Error("Maven executable [" + mavenExe + "] not found");
         }
         const cmdArgs: string[] = [
-            "archetype:generate",
+            "org.apache.maven.plugins:maven-archetype-plugin:3.2.1:generate",
             `-DarchetypeArtifactId=payara-starter-archetype`,
             `-DarchetypeGroupId=fish.payara.starter`,
             `-DarchetypeVersion=1.0-beta9`,

--- a/src/main/fish/payara/project/Maven.ts
+++ b/src/main/fish/payara/project/Maven.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Copyright (c) 2020-2022 Payara Foundation and/or its affiliates and others.
+ * Copyright (c) 2020-2024 Payara Foundation and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -289,15 +289,11 @@ export class Maven implements Build {
             `-DpayaraMicroVersion=${project.payaraMicroVersion}`,
             '-DaddPayaraApi=true',
             '-DinteractiveMode=false',
-            '-DjakartaEEVersion='+ (project.payaraMicroVersion.split('.')[0] === '5' ? '8' : '10')
+            '-DjakartaEEVersion='+ (project.payaraMicroVersion.split('.')[0] === '5' ? '8' : '10'),
+            '-Dplatform=micro'
         ];
 
-        /**
-         * String PROP_PLATFORM = "platform";
-         * String PROP_PLATFORM_MICRO_VALUE = "micro";
-         * properties.put(PROP_PLATFORM, PROP_PLATFORM_MICRO_VALUE)
-         */
-        let process: ChildProcess = cp.spawn(mavenExe, cmdArgs, { cwd: project.targetFolder?.fsPath, shell: true });
+        let process: ChildProcess = cp.spawn(mavenExe, cmdArgs, { cwd: project.targetFolder?.fsPath });
 
         if (process.pid) {
             let outputChannel = ProjectOutputWindowProvider.getInstance().get(`${project.artifactId}`);

--- a/src/main/fish/payara/project/Maven.ts
+++ b/src/main/fish/payara/project/Maven.ts
@@ -279,18 +279,25 @@ export class Maven implements Build {
         }
         const cmdArgs: string[] = [
             "archetype:generate",
-            `-DarchetypeArtifactId=payara-micro-maven-archetype`,
-            `-DarchetypeGroupId=fish.payara.maven.archetypes`,
-            `-DarchetypeVersion=` + (project.payaraMicroVersion.split('.')[0] === '5' ? '1.0.5' : '2.0'),
+            `-DarchetypeArtifactId=payara-starter-archetype`,
+            `-DarchetypeGroupId=fish.payara.starter`,
+            `-DarchetypeVersion=1.0-beta9`,
             `-DgroupId=${project.groupId}`,
             `-DartifactId=${project.artifactId}`,
             `-Dversion=${project.version}`,
             `-Dpackage=${project.package}`,
             `-DpayaraMicroVersion=${project.payaraMicroVersion}`,
             '-DaddPayaraApi=true',
-            '-DinteractiveMode=false'
+            '-DinteractiveMode=false',
+            '-DjakartaEEVersion='+ (project.payaraMicroVersion.split('.')[0] === '5' ? '8' : '10')
         ];
-        let process: ChildProcess = cp.spawn(mavenExe, cmdArgs, { cwd: project.targetFolder?.fsPath });
+
+        /**
+         * String PROP_PLATFORM = "platform";
+         * String PROP_PLATFORM_MICRO_VALUE = "micro";
+         * properties.put(PROP_PLATFORM, PROP_PLATFORM_MICRO_VALUE)
+         */
+        let process: ChildProcess = cp.spawn(mavenExe, cmdArgs, { cwd: project.targetFolder?.fsPath, shell: true });
 
         if (process.pid) {
             let outputChannel = ProjectOutputWindowProvider.getInstance().get(`${project.artifactId}`);


### PR DESCRIPTION
I have added the platform in the generation settings along with the updated archetype settings. Added the JEE version depending on the micro version selected. 

**I was not sure whether to swap the `archetype:generate` with the maven archetype cmd command `org.apache.maven.plugins:maven-archetype-plugin:3.2.1:generate` to reflect the changes in the Payara Starter.**