### PR TITLE
FISH-13801 Payara Server Maven Plugin support

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,8 @@
+{
+    "require": [
+        "src/test/unit/vscode-mock.js",
+        "ts-node/register"
+    ],
+    "spec": "src/test/unit/**/*.test.ts",
+    "timeout": 10000
+}

--- a/README.md
+++ b/README.md
@@ -5,3 +5,87 @@ Support for the VS Code IDE Payara Tools plugin is handled in the [Ecosystem Sup
 
 ### VS Code Payara Tools Documentation
 Full documentation for the configuration and usage of the VS Code Payara Tools plugin can be found in the [technical documentation](https://docs.payara.fish/community/docs/Technical%20Documentation/Ecosystem/IDE%20Integration/VSCode%20Extension/Overview.html)
+
+---
+
+## Customizing Build Commands
+
+The extension uses default Maven/Gradle commands for each action. You can override any command by adding a matching task to your project's `.vscode/tasks.json`. The extension matches tasks by their `label` field and uses your custom `command` instead of the default.
+
+### How to override
+
+Create or edit `.vscode/tasks.json` in your project root:
+
+```json
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "payara-server-maven-start",
+      "type": "shell",
+      "command": "mvn clean package fish.payara.maven.plugins:payara-server-maven-plugin:start"
+    }
+  ]
+}
+```
+
+> **Note:** The extension writes the default task to `.vscode/tasks.json` the first time it runs an action, so you can edit it in place.
+
+### Available task labels
+
+#### Payara Server Maven Plugin (`payara-server-maven-plugin`)
+
+| Label | Default command |
+|---|---|
+| `payara-server-maven-start` | `mvn package fish.payara.maven.plugins:payara-server-maven-plugin:start` |
+| `payara-server-maven-dev` | `mvn package fish.payara.maven.plugins:payara-server-maven-plugin:dev` |
+| `payara-server-maven-stop` | `mvn fish.payara.maven.plugins:payara-server-maven-plugin:stop` |
+
+#### Payara Micro Maven Plugin (`payara-micro-maven-plugin`)
+
+| Label | Default command |
+|---|---|
+| `payara-micro-exploded-war-start` | `mvn resources:resources compiler:compile war:exploded … payara-micro-maven-plugin:start` |
+| `payara-micro-uber-jar-start` | `mvn install … payara-micro-maven-plugin:bundle payara-micro-maven-plugin:start` |
+| `payara-micro-dev` | `mvn fish.payara.maven.plugins:payara-micro-maven-plugin:dev` |
+| `payara-micro-reload` | `mvn resources:resources compiler:compile war:exploded … payara-micro-maven-plugin:reload` |
+| `payara-micro-stop` | `mvn fish.payara.maven.plugins:payara-micro-maven-plugin:stop` |
+| `payara-micro-bundle` | `mvn install … payara-micro-maven-plugin:bundle` |
+
+#### Payara Server (traditional deployment)
+
+| Label | Default command |
+|---|---|
+| `payara-server-build` | `mvn resources:resources compiler:compile war:war` (remote) or `war:exploded` (local) |
+
+---
+
+## Configuring the Debug Port
+
+When you click **Start in Debug Mode** or **Start (Dev Mode) in Debug**, the extension attaches the VS Code Java debugger to the running server. The debug port defaults to **5005** for Payara Server Maven and Payara Micro.
+
+On the first debug launch the extension automatically creates a configuration entry in `.vscode/launch.json`. To use a different port, edit that entry:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "java",
+      "request": "attach",
+      "name": "payara-server-maven",
+      "hostName": "localhost",
+      "port": 8000
+    },
+    {
+      "type": "java",
+      "request": "attach",
+      "name": "payara-micro",
+      "hostName": "localhost",
+      "port": 8000
+    }
+  ]
+}
+```
+
+The extension matches the configuration by `name`, so keep the name unchanged (`payara-server-maven` or `payara-micro`). Only the `port` (and optionally `hostName`) need to be adjusted.

--- a/package.json
+++ b/package.json
@@ -444,7 +444,8 @@
 				{
 					"type": "webview",
 					"id": "payara.ai.chat",
-					"name": "Payara AI Agent"
+					"name": "Payara AI Agent",
+					"retainContextWhenHidden": true
 				}
 			]
 		},
@@ -467,11 +468,19 @@
 		"viewsWelcome": [
 			{
 				"view": "payaraServerMaven",
-				"contents": "No Maven project found in the current workspace.\nOpen a folder containing a pom.xml to get started."
+				"contents": "No Maven projects are open in the Explorer.\n[Open Project](command:workbench.action.files.openFolder)"
 			},
 			{
 				"view": "payaraServerMavenExplorer",
-				"contents": "No Maven project found in the current workspace.\nOpen a folder containing a pom.xml to get started."
+				"contents": "No Maven projects are open in the Explorer.\n[Open Project](command:workbench.action.files.openFolder)"
+			},
+			{
+				"view": "payaraMicro",
+				"contents": "No Maven projects are open in the Explorer.\n[Open Project](command:workbench.action.files.openFolder)"
+			},
+			{
+				"view": "payaraMicroExplorer",
+				"contents": "No Maven projects are open in the Explorer.\n[Open Project](command:workbench.action.files.openFolder)"
 			}
 		],
 		"menus": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
 		"onCommand:payara.server.maven.deploy.settings",
 		"onView:payaraServerMavenExplorer",
 		"onView:payaraServerMaven",
-		"onCommand:payara.ai.selectModel"
+		"onCommand:payara.ai.selectModel",
+		"onView:payara.ai.chat"
 	],
 	"main": "./out/main/extension.js",
 	"contributes": {
@@ -438,6 +439,13 @@
 					"id": "payaraServerMaven",
 					"name": "Server Projects"
 				}
+			],
+			"payaraAiPanel": [
+				{
+					"type": "webview",
+					"id": "payara.ai.chat",
+					"name": "Payara AI Agent"
+				}
 			]
 		},
 		"viewsContainers": {
@@ -447,8 +455,25 @@
 					"title": "Payara",
 					"icon": "resources/payara.svg"
 				}
+			],
+			"panel": [
+				{
+					"id": "payaraAiPanel",
+					"title": "Payara AI Agent",
+					"icon": "resources/payara.svg"
+				}
 			]
 		},
+		"viewsWelcome": [
+			{
+				"view": "payaraServerMaven",
+				"contents": "No Maven project found in the current workspace.\nOpen a folder containing a pom.xml to get started."
+			},
+			{
+				"view": "payaraServerMavenExplorer",
+				"contents": "No Maven project found in the current workspace.\nOpen a folder containing a pom.xml to get started."
+			}
+		],
 		"menus": {
 			"view/title": [
 				{

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "payara-vscode",
 	"displayName": "Payara Tools",
 	"description": "Payara Tools for Visual Studio Code",
-	"version": "1.7.0-SNAPSHOT",
+	"version": "1.6.0-SNAPSHOT",
 	"publisher": "Payara",
 	"icon": "resources/payara.png",
 	"repository": {
@@ -51,6 +51,8 @@
 		"onCommand:payara.micro.refresh.all",
 		"onCommand:payara.micro.start",
 		"onCommand:payara.micro.start.debug",
+		"onCommand:payara.micro.start.dev",
+		"onCommand:payara.micro.start.dev.debug",
 		"onCommand:payara.micro.reload",
 		"onCommand:payara.micro.stop",
 		"onCommand:payara.micro.bundle",
@@ -59,7 +61,18 @@
 		"onView:payaraServerExplorer",
 		"onView:payaraServer",
 		"onView:payaraMicroExplorer",
-		"onView:payaraMicro"
+		"onView:payaraMicro",
+		"onCommand:payara.server.maven.refresh",
+		"onCommand:payara.server.maven.refresh.all",
+		"onCommand:payara.server.maven.start",
+		"onCommand:payara.server.maven.start.debug",
+		"onCommand:payara.server.maven.start.dev",
+		"onCommand:payara.server.maven.start.dev.debug",
+		"onCommand:payara.server.maven.stop",
+		"onCommand:payara.server.maven.jdk.home",
+		"onCommand:payara.server.maven.deploy.settings",
+		"onView:payaraServerMavenExplorer",
+		"onView:payaraServerMaven"
 	],
 	"main": "./out/main/extension.js",
 	"contributes": {
@@ -263,6 +276,24 @@
 				}
 			},
 			{
+				"command": "payara.micro.start.dev",
+				"title": "Start (Dev Mode)",
+				"category": "Payara",
+				"icon": {
+					"light": "resources/theme/light/dev.svg",
+					"dark": "resources/theme/dark/dev.svg"
+				}
+			},
+			{
+				"command": "payara.micro.start.dev.debug",
+				"title": "Start (Dev Mode) in Debug",
+				"category": "Payara",
+				"icon": {
+					"light": "resources/theme/light/dev-debug.svg",
+					"dark": "resources/theme/dark/dev-debug.svg"
+				}
+			},
+			{
 				"command": "payara.micro.reload",
 				"title": "Reload",
 				"category": "Payara",
@@ -298,6 +329,79 @@
 				"command": "payara.micro.deploy.settings",
 				"title": "Deployment settings",
 				"category": "Payara"
+			},
+			{
+				"command": "payara.server.maven.refresh.all",
+				"title": "Refresh All",
+				"category": "Payara",
+				"icon": {
+					"light": "resources/theme/light/refresh.svg",
+					"dark": "resources/theme/dark/refresh.svg"
+				}
+			},
+			{
+				"command": "payara.server.maven.refresh",
+				"title": "Refresh",
+				"category": "Payara",
+				"icon": {
+					"light": "resources/theme/light/refresh.svg",
+					"dark": "resources/theme/dark/refresh.svg"
+				}
+			},
+			{
+				"command": "payara.server.maven.start",
+				"title": "Start",
+				"category": "Payara",
+				"icon": {
+					"light": "resources/theme/light/start.svg",
+					"dark": "resources/theme/dark/start.svg"
+				}
+			},
+			{
+				"command": "payara.server.maven.start.debug",
+				"title": "Start in Debug Mode",
+				"category": "Payara",
+				"icon": {
+					"light": "resources/theme/light/debug.svg",
+					"dark": "resources/theme/dark/debug.svg"
+				}
+			},
+			{
+				"command": "payara.server.maven.start.dev",
+				"title": "Start (Dev Mode)",
+				"category": "Payara",
+				"icon": {
+					"light": "resources/theme/light/dev.svg",
+					"dark": "resources/theme/dark/dev.svg"
+				}
+			},
+			{
+				"command": "payara.server.maven.start.dev.debug",
+				"title": "Start (Dev Mode) in Debug",
+				"category": "Payara",
+				"icon": {
+					"light": "resources/theme/light/dev-debug.svg",
+					"dark": "resources/theme/dark/dev-debug.svg"
+				}
+			},
+			{
+				"command": "payara.server.maven.stop",
+				"title": "Stop",
+				"category": "Payara",
+				"icon": {
+					"light": "resources/theme/light/stop.svg",
+					"dark": "resources/theme/dark/stop.svg"
+				}
+			},
+			{
+				"command": "payara.server.maven.jdk.home",
+				"title": "JDK Home",
+				"category": "Payara"
+			},
+			{
+				"command": "payara.server.maven.deploy.settings",
+				"title": "Deployment settings",
+				"category": "Payara"
 			}
 		],
 		"views": {
@@ -309,6 +413,10 @@
 				{
 					"id": "payaraMicroExplorer",
 					"name": "Payara Micro Instances"
+				},
+				{
+					"id": "payaraServerMavenExplorer",
+					"name": "Payara Server Projects"
 				}
 			],
 			"payaraActivitybar": [
@@ -319,6 +427,10 @@
 				{
 					"id": "payaraMicro",
 					"name": "Micro Instances"
+				},
+				{
+					"id": "payaraServerMaven",
+					"name": "Server Projects"
 				}
 			]
 		},
@@ -362,6 +474,11 @@
 					"command": "payara.micro.stop",
 					"when": "viewItem == loadingPayaraMicro || viewItem == runningPayaraMicro",
 					"group": "navigation@5"
+				},
+				{
+					"command": "payara.server.maven.refresh.all",
+					"when": "view == payaraServerMavenExplorer || view == payaraServerMaven",
+					"group": "navigation@6"
 				}
 			],
 			"commandPalette": [
@@ -470,6 +587,14 @@
 					"when": "never"
 				},
 				{
+					"command": "payara.micro.start.dev",
+					"when": "never"
+				},
+				{
+					"command": "payara.micro.start.dev.debug",
+					"when": "never"
+				},
+				{
 					"command": "payara.micro.reload",
 					"when": "never"
 				},
@@ -487,6 +612,34 @@
 				},
 				{
 					"command": "payara.micro.deploy.settings",
+					"when": "never"
+				},
+				{
+					"command": "payara.server.maven.start",
+					"when": "never"
+				},
+				{
+					"command": "payara.server.maven.start.debug",
+					"when": "never"
+				},
+				{
+					"command": "payara.server.maven.start.dev",
+					"when": "never"
+				},
+				{
+					"command": "payara.server.maven.start.dev.debug",
+					"when": "never"
+				},
+				{
+					"command": "payara.server.maven.stop",
+					"when": "never"
+				},
+				{
+					"command": "payara.server.maven.jdk.home",
+					"when": "never"
+				},
+				{
+					"command": "payara.server.maven.deploy.settings",
 					"when": "never"
 				}
 			],
@@ -644,6 +797,16 @@
 					"group": "inline"
 				},
 				{
+					"command": "payara.micro.start.dev",
+					"when": "viewItem == stoppedPayaraMicro",
+					"group": "inline"
+				},
+				{
+					"command": "payara.micro.start.dev.debug",
+					"when": "viewItem == stoppedPayaraMicro",
+					"group": "inline"
+				},
+				{
 					"command": "payara.micro.reload",
 					"when": "viewItem == runningPayaraMicro",
 					"group": "inline"
@@ -664,29 +827,99 @@
 					"group": "payara-micro@1"
 				},
 				{
+					"command": "payara.micro.start.dev",
+					"when": "viewItem == stoppedPayaraMicro",
+					"group": "payara-micro@2"
+				},
+				{
+					"command": "payara.micro.start.dev.debug",
+					"when": "viewItem == stoppedPayaraMicro",
+					"group": "payara-micro@3"
+				},
+				{
 					"command": "payara.micro.reload",
 					"when": "viewItem == runningPayaraMicro",
-					"group": "payara-micro@2"
+					"group": "payara-micro@4"
 				},
 				{
 					"command": "payara.micro.stop",
 					"when": "viewItem == loadingPayaraMicro || viewItem == runningPayaraMicro",
-					"group": "payara-micro@3"
+					"group": "payara-micro@4"
 				},
 				{
 					"command": "payara.micro.bundle",
 					"when": "viewItem == stoppedPayaraMicro || viewItem == runningPayaraMicro",
-					"group": "payara-micro@4"
+					"group": "payara-micro@5"
 				},
 				{
 					"command": "payara.micro.jdk.home",
 					"when": "viewItem == loadingPayaraMicro || viewItem == runningPayaraMicro || viewItem == stoppedPayaraMicro",
-					"group": "payara-micro@5"
+					"group": "payara-micro@6"
 				},
 				{
 					"command": "payara.micro.deploy.settings",
 					"when": "viewItem == loadingPayaraMicro || viewItem == runningPayaraMicro || viewItem == stoppedPayaraMicro",
-					"group": "payara-micro@6"
+					"group": "payara-micro@7"
+				},
+				{
+					"command": "payara.server.maven.start",
+					"when": "viewItem == stoppedPayaraServerMaven",
+					"group": "inline"
+				},
+				{
+					"command": "payara.server.maven.start.debug",
+					"when": "viewItem == stoppedPayaraServerMaven",
+					"group": "inline"
+				},
+				{
+					"command": "payara.server.maven.start.dev",
+					"when": "viewItem == stoppedPayaraServerMaven",
+					"group": "inline"
+				},
+				{
+					"command": "payara.server.maven.start.dev.debug",
+					"when": "viewItem == stoppedPayaraServerMaven",
+					"group": "inline"
+				},
+				{
+					"command": "payara.server.maven.stop",
+					"when": "viewItem == loadingPayaraServerMaven || viewItem == runningPayaraServerMaven",
+					"group": "inline"
+				},
+				{
+					"command": "payara.server.maven.start",
+					"when": "viewItem == stoppedPayaraServerMaven",
+					"group": "payara-server-maven@0"
+				},
+				{
+					"command": "payara.server.maven.start.debug",
+					"when": "viewItem == stoppedPayaraServerMaven",
+					"group": "payara-server-maven@1"
+				},
+				{
+					"command": "payara.server.maven.start.dev",
+					"when": "viewItem == stoppedPayaraServerMaven",
+					"group": "payara-server-maven@2"
+				},
+				{
+					"command": "payara.server.maven.start.dev.debug",
+					"when": "viewItem == stoppedPayaraServerMaven",
+					"group": "payara-server-maven@3"
+				},
+				{
+					"command": "payara.server.maven.stop",
+					"when": "viewItem == loadingPayaraServerMaven || viewItem == runningPayaraServerMaven",
+					"group": "payara-server-maven@4"
+				},
+				{
+					"command": "payara.server.maven.jdk.home",
+					"when": "viewItem == loadingPayaraServerMaven || viewItem == runningPayaraServerMaven || viewItem == stoppedPayaraServerMaven",
+					"group": "payara-server-maven@5"
+				},
+				{
+					"command": "payara.server.maven.deploy.settings",
+					"when": "viewItem == loadingPayaraServerMaven || viewItem == runningPayaraServerMaven || viewItem == stoppedPayaraServerMaven",
+					"group": "payara-server-maven@6"
 				},
 				{
 					"command": "payara.server.app.deploy",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
 		"onCommand:payara.server.maven.jdk.home",
 		"onCommand:payara.server.maven.deploy.settings",
 		"onView:payaraServerMavenExplorer",
-		"onView:payaraServerMaven"
+		"onView:payaraServerMaven",
+		"onCommand:payara.ai.selectModel"
 	],
 	"main": "./out/main/extension.js",
 	"contributes": {
@@ -401,6 +402,11 @@
 			{
 				"command": "payara.server.maven.deploy.settings",
 				"title": "Deployment settings",
+				"category": "Payara"
+			},
+			{
+				"command": "payara.ai.selectModel",
+				"title": "Select AI Model",
 				"category": "Payara"
 			}
 		],
@@ -914,12 +920,12 @@
 				{
 					"command": "payara.server.maven.jdk.home",
 					"when": "viewItem == loadingPayaraServerMaven || viewItem == runningPayaraServerMaven || viewItem == stoppedPayaraServerMaven",
-					"group": "payara-server-maven@5"
+					"group": "payara-server-maven@6"
 				},
 				{
 					"command": "payara.server.maven.deploy.settings",
 					"when": "viewItem == loadingPayaraServerMaven || viewItem == runningPayaraServerMaven || viewItem == stoppedPayaraServerMaven",
-					"group": "payara-server-maven@6"
+					"group": "payara-server-maven@7"
 				},
 				{
 					"command": "payara.server.app.deploy",
@@ -937,6 +943,198 @@
 					"group": "java-project@1"
 				}
 			]
+		},
+		"configuration": {
+			"title": "Payara",
+			"properties": {
+				"payara.ai.agent": {
+					"order": 0,
+					"type": "boolean",
+					"default": false,
+					"description": "Enable the Payara AI Agent. When disabled, no AI properties are passed to Maven."
+				},
+				"payara.ai.apiKey": {
+					"order": 1,
+					"type": "string",
+					"default": "",
+					"description": "API key for the AI provider used by Payara AI Agent."
+				},
+				"payara.ai.provider": {
+					"order": 2,
+					"type": "string",
+					"default": "OPEN_AI",
+					"enum": [
+						"OPEN_AI",
+						"CUSTOM_OPEN_AI",
+						"GOOGLE",
+						"DEEPINFRA",
+						"DEEPSEEK",
+						"GROQ",
+						"MISTRAL",
+						"OLLAMA",
+						"ANTHROPIC",
+						"LM_STUDIO",
+						"GPT4ALL"
+					],
+					"description": "AI provider for Payara AI Agent."
+				},
+				"payara.ai.model": {
+					"order": 3,
+					"type": "string",
+					"default": "",
+					"markdownDescription": "AI model name. Click **[Select AI Model](command:payara.ai.selectModel)** to browse available models for the selected provider."
+				},
+				"payara.ai.providerLocation": {
+					"order": 4,
+					"type": "string",
+					"default": "",
+					"description": "Base URL for local or custom AI provider (e.g., http://localhost:11434 for Ollama)."
+				},
+				"payara.ai.organizationId": {
+					"type": "string",
+					"default": "",
+					"description": "Organization ID for OpenAI or compatible providers."
+				},
+				"payara.ai.temperature": {
+					"type": [
+						"number",
+						"null"
+					],
+					"default": null,
+					"description": "Sampling temperature (0.0-2.0). Higher values produce more random output."
+				},
+				"payara.ai.topP": {
+					"type": [
+						"number",
+						"null"
+					],
+					"default": null,
+					"description": "Nucleus sampling probability mass (0.0-1.0)."
+				},
+				"payara.ai.topK": {
+					"type": [
+						"integer",
+						"null"
+					],
+					"default": null,
+					"description": "Top-K sampling limit. Supported by some providers (e.g., Ollama, Google)."
+				},
+				"payara.ai.maxTokens": {
+					"type": [
+						"integer",
+						"null"
+					],
+					"default": null,
+					"description": "Maximum number of tokens in the response (legacy OpenAI parameter)."
+				},
+				"payara.ai.maxCompletionTokens": {
+					"type": [
+						"integer",
+						"null"
+					],
+					"default": null,
+					"description": "Maximum completion tokens (newer OpenAI models)."
+				},
+				"payara.ai.maxOutputTokens": {
+					"type": [
+						"integer",
+						"null"
+					],
+					"default": null,
+					"description": "Maximum output tokens (Anthropic / Google)."
+				},
+				"payara.ai.presencePenalty": {
+					"type": [
+						"number",
+						"null"
+					],
+					"default": null,
+					"description": "Presence penalty (-2.0-2.0) to discourage topic repetition."
+				},
+				"payara.ai.frequencyPenalty": {
+					"type": [
+						"number",
+						"null"
+					],
+					"default": null,
+					"description": "Frequency penalty (-2.0-2.0) to reduce word repetition."
+				},
+				"payara.ai.repeatPenalty": {
+					"type": [
+						"number",
+						"null"
+					],
+					"default": null,
+					"description": "Repeat penalty for local models such as Ollama."
+				},
+				"payara.ai.seed": {
+					"type": [
+						"integer",
+						"null"
+					],
+					"default": null,
+					"description": "Random seed for deterministic outputs."
+				},
+				"payara.ai.timeout": {
+					"type": [
+						"integer",
+						"null"
+					],
+					"default": null,
+					"description": "HTTP request timeout in seconds. Defaults to 600 if not set."
+				},
+				"payara.ai.maxRetries": {
+					"type": [
+						"integer",
+						"null"
+					],
+					"default": null,
+					"description": "Number of retry attempts on transient errors."
+				},
+				"payara.ai.stream": {
+					"type": "boolean",
+					"default": false,
+					"description": "Enable streaming responses from the AI provider."
+				},
+				"payara.ai.logRequests": {
+					"type": "boolean",
+					"default": false,
+					"description": "Log outgoing AI requests to the console (useful for debugging)."
+				},
+				"payara.ai.logResponses": {
+					"type": "boolean",
+					"default": false,
+					"description": "Log AI responses to the console (useful for debugging)."
+				},
+				"payara.ai.allowCodeExecution": {
+					"type": "boolean",
+					"default": false,
+					"description": "Allow the AI agent to execute code snippets it generates."
+				},
+				"payara.ai.includeCodeExecutionOutput": {
+					"type": "boolean",
+					"default": false,
+					"description": "Include code execution output in the AI agent response."
+				},
+				"payara.ai.chatHistory": {
+					"type": "boolean",
+					"default": false,
+					"description": "Enable chat history so the AI agent remembers previous messages in a session."
+				},
+				"payara.ai.chatHistoryLimit": {
+					"type": [
+						"integer",
+						"null"
+					],
+					"default": null,
+					"description": "Maximum number of past exchanges kept in chat history. Defaults to 3."
+				},
+				"payara.ai.customHeaders": {
+					"type": "string",
+					"default": "",
+					"description": "Semicolon-separated custom HTTP headers sent to the AI provider (e.g., X-Header1=value1;X-Header2=value2)."
+				}
+			}
 		}
 	},
 	"scripts": {
@@ -944,6 +1142,7 @@
 		"compile": "tsc -p ./",
 		"watch": "tsc -watch -p ./",
 		"pretest": "yarn run compile",
+		"test:unit": "mocha",
 		"test:e2e": "playwright test -c src/test/e2e/playwright.config.ts",
 		"tslint": "tslint -t verbose src/**/*.ts"
 	},
@@ -969,11 +1168,14 @@
 		"@types/lodash": "^4.17.24",
 		"@types/mocha": "10.0.10",
 		"@types/node": "^25.4.0",
+		"@types/sinon": "^17.0.3",
 		"@types/vscode": "^1.109.0",
 		"@vscode/test-electron": "2.5.2",
 		"glob": "^13.0.6",
 		"mocha": "11.7.5",
 		"playwright": "^1.58.2",
+		"sinon": "^18.0.0",
+		"ts-node": "^10.9.2",
 		"tslint": "^6.1.0",
 		"typescript": "^5.9.3"
 	},

--- a/resources/theme/dark/dev-debug.svg
+++ b/resources/theme/dark/dev-debug.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 28 24" fill="none" stroke="#C5C5C5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <polygon points="18 2 8 14 17 14 16 22 26 10 17 10 18 2" fill="#C5C5C5" opacity="0.45"/>
+    <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
+</svg>

--- a/resources/theme/dark/dev.svg
+++ b/resources/theme/dark/dev.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#C5C5C5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
+</svg>

--- a/resources/theme/light/dev-debug.svg
+++ b/resources/theme/light/dev-debug.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 28 24" fill="none" stroke="#424242" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <polygon points="18 2 8 14 17 14 16 22 26 10 17 10 18 2" fill="#424242" opacity="0.45"/>
+    <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
+</svg>

--- a/resources/theme/light/dev.svg
+++ b/resources/theme/light/dev.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#424242" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
+</svg>

--- a/src/main/extension.ts
+++ b/src/main/extension.ts
@@ -32,6 +32,7 @@ import * as path from 'path';
 import { PayaraRemoteServerInstance } from './fish/payara/server/PayaraRemoteServerInstance';
 import { DeployOption } from './fish/payara/common/DeployOption';
 import { Uri, WorkspaceFolder } from 'vscode';
+import { selectAIModel } from './fish/payara/ai/AIModelFetcher';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
 
@@ -404,7 +405,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 			payaraServerMaven => payaraServerMavenInstanceController.deploySettings(payaraServerMaven)
 		)
 	);
-
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			'payara.ai.selectModel',
+			() => selectAIModel()
+		)
+	);
 	vscode.workspace.onDidSaveTextDocument((document: vscode.TextDocument) => {
 		const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
 		let metadataChanged = true;

--- a/src/main/extension.ts
+++ b/src/main/extension.ts
@@ -37,14 +37,18 @@ import { selectAIModel } from './fish/payara/ai/AIModelFetcher';
 import { PayaraAIChatViewProvider } from './fish/payara/ai/PayaraAIChatViewProvider';
 
 let _mavenInstanceProvider: PayaraServerMavenInstanceProvider | undefined;
+let _microInstanceProvider: PayaraMicroInstanceProvider | undefined;
 
 export function deactivate(): void {
     killAllMavenInstances();
 }
 
 function killAllMavenInstances(): void {
-    if (!_mavenInstanceProvider) { return; }
-    for (const instance of _mavenInstanceProvider.getAllInstances()) {
+    const instances = [
+        ...(_mavenInstanceProvider?.getAllInstances() ?? []),
+        ...(_microInstanceProvider?.getMicroInstances() ?? []),
+    ];
+    for (const instance of instances) {
         const proc = instance.getProcess();
         if (proc?.pid && !proc.killed) {
             try {
@@ -65,6 +69,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	const payaraServerInstanceController: PayaraServerInstanceController = new PayaraServerInstanceController(context, payaraServerInstanceProvider, context.extensionPath);
 
 	const payaraMicroInstanceProvider: PayaraMicroInstanceProvider = new PayaraMicroInstanceProvider(context);
+	_microInstanceProvider = payaraMicroInstanceProvider;
 	const payaraMicroTree: PayaraMicroTreeDataProvider = new PayaraMicroTreeDataProvider(context, payaraMicroInstanceProvider);
 	const payaraMicroInstanceController: PayaraMicroInstanceController = new PayaraMicroInstanceController(context, payaraMicroInstanceProvider, context.extensionPath);
 	const payaraMicroProjectGenerator: PayaraMicroProjectGenerator = new PayaraMicroProjectGenerator(payaraMicroInstanceController);

--- a/src/main/extension.ts
+++ b/src/main/extension.ts
@@ -18,6 +18,7 @@
  */
 
 import * as vscode from 'vscode';
+import * as cp from 'child_process';
 import { PayaraInstanceProvider } from "./fish/payara/server/PayaraInstanceProvider";
 import { PayaraServerInstanceController } from "./fish/payara/server/PayaraServerInstanceController";
 import { PayaraServerTreeDataProvider } from "./fish/payara/server/PayaraServerTreeDataProvider";
@@ -33,6 +34,29 @@ import { PayaraRemoteServerInstance } from './fish/payara/server/PayaraRemoteSer
 import { DeployOption } from './fish/payara/common/DeployOption';
 import { Uri, WorkspaceFolder } from 'vscode';
 import { selectAIModel } from './fish/payara/ai/AIModelFetcher';
+import { PayaraAIChatViewProvider } from './fish/payara/ai/PayaraAIChatViewProvider';
+
+let _mavenInstanceProvider: PayaraServerMavenInstanceProvider | undefined;
+
+export function deactivate(): void {
+    killAllMavenInstances();
+}
+
+function killAllMavenInstances(): void {
+    if (!_mavenInstanceProvider) { return; }
+    for (const instance of _mavenInstanceProvider.getAllInstances()) {
+        const proc = instance.getProcess();
+        if (proc?.pid && !proc.killed) {
+            try {
+                if (process.platform === 'win32') {
+                    cp.execSync(`taskkill /F /T /PID ${proc.pid}`, { stdio: 'ignore' });
+                } else {
+                    proc.kill('SIGTERM');
+                }
+            } catch (_) { /* already gone */ }
+        }
+    }
+}
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
 
@@ -46,8 +70,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	const payaraMicroProjectGenerator: PayaraMicroProjectGenerator = new PayaraMicroProjectGenerator(payaraMicroInstanceController);
 
 	const payaraServerMavenInstanceProvider: PayaraServerMavenInstanceProvider = new PayaraServerMavenInstanceProvider(context);
+	_mavenInstanceProvider = payaraServerMavenInstanceProvider;
 	const payaraServerMavenTree: PayaraServerMavenTreeDataProvider = new PayaraServerMavenTreeDataProvider(context, payaraServerMavenInstanceProvider);
-	const payaraServerMavenInstanceController: PayaraServerMavenInstanceController = new PayaraServerMavenInstanceController(context, payaraServerMavenInstanceProvider, context.extensionPath);
+	const payaraAiChatProvider: PayaraAIChatViewProvider = new PayaraAIChatViewProvider(context.extensionUri);
+	const payaraServerMavenInstanceController: PayaraServerMavenInstanceController = new PayaraServerMavenInstanceController(context, payaraServerMavenInstanceProvider, context.extensionPath, payaraAiChatProvider);
+
+	// Kill any still-running Payara Server Maven process trees when VS Code shuts down.
+	context.subscriptions.push({ dispose: killAllMavenInstances });
 
 	context.subscriptions.push(
 		vscode.window.registerTreeDataProvider(
@@ -77,6 +106,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	context.subscriptions.push(
 		vscode.window.registerTreeDataProvider(
 			'payaraServerMaven', payaraServerMavenTree
+		)
+	);
+	context.subscriptions.push(
+		vscode.window.registerWebviewViewProvider(
+			PayaraAIChatViewProvider.viewType,
+			payaraAiChatProvider
 		)
 	);
 	context.subscriptions.push(
@@ -487,8 +522,5 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 			}
 		}
 	});
-
 }
 
-// this method is called when your extension is deactivated
-export function deactivate() { }

--- a/src/main/extension.ts
+++ b/src/main/extension.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Copyright (c) 2020-2021 Payara Foundation and/or its affiliates and others.
+ * Copyright (c) 2020-2026 Payara Foundation and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -25,6 +25,9 @@ import { PayaraMicroProjectGenerator } from './fish/payara/micro/PayaraMicroProj
 import { PayaraMicroTreeDataProvider } from './fish/payara/micro/PayaraMicroTreeDataProvider';
 import { PayaraMicroInstanceProvider } from './fish/payara/micro/PayaraMicroInstanceProvider';
 import { PayaraMicroInstanceController } from './fish/payara/micro/PayaraMicroInstanceController';
+import { PayaraServerMavenInstanceProvider } from './fish/payara/server/maven/PayaraServerMavenInstanceProvider';
+import { PayaraServerMavenTreeDataProvider } from './fish/payara/server/maven/PayaraServerMavenTreeDataProvider';
+import { PayaraServerMavenInstanceController } from './fish/payara/server/maven/PayaraServerMavenInstanceController';
 import * as path from 'path';
 import { PayaraRemoteServerInstance } from './fish/payara/server/PayaraRemoteServerInstance';
 import { DeployOption } from './fish/payara/common/DeployOption';
@@ -40,6 +43,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	const payaraMicroTree: PayaraMicroTreeDataProvider = new PayaraMicroTreeDataProvider(context, payaraMicroInstanceProvider);
 	const payaraMicroInstanceController: PayaraMicroInstanceController = new PayaraMicroInstanceController(context, payaraMicroInstanceProvider, context.extensionPath);
 	const payaraMicroProjectGenerator: PayaraMicroProjectGenerator = new PayaraMicroProjectGenerator(payaraMicroInstanceController);
+
+	const payaraServerMavenInstanceProvider: PayaraServerMavenInstanceProvider = new PayaraServerMavenInstanceProvider(context);
+	const payaraServerMavenTree: PayaraServerMavenTreeDataProvider = new PayaraServerMavenTreeDataProvider(context, payaraServerMavenInstanceProvider);
+	const payaraServerMavenInstanceController: PayaraServerMavenInstanceController = new PayaraServerMavenInstanceController(context, payaraServerMavenInstanceProvider, context.extensionPath);
 
 	context.subscriptions.push(
 		vscode.window.registerTreeDataProvider(
@@ -59,6 +66,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	context.subscriptions.push(
 		vscode.window.registerTreeDataProvider(
 			'payaraMicro', payaraMicroTree
+		)
+	);
+	context.subscriptions.push(
+		vscode.window.registerTreeDataProvider(
+			'payaraServerMavenExplorer', payaraServerMavenTree
+		)
+	);
+	context.subscriptions.push(
+		vscode.window.registerTreeDataProvider(
+			'payaraServerMaven', payaraServerMavenTree
 		)
 	);
 	context.subscriptions.push(
@@ -280,6 +297,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	);
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
+			'payara.micro.start.dev',
+			payaraMicro => payaraMicroInstanceController.devMicro(payaraMicro, false)
+		)
+	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			'payara.micro.start.dev.debug',
+			payaraMicro => payaraMicroInstanceController.devMicro(payaraMicro, true)
+		)
+	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
 			'payara.micro.reload',
 			payaraMicro => payaraMicroInstanceController.reloadMicro(payaraMicro)
 		)
@@ -312,6 +341,67 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 		vscode.commands.registerCommand(
 			'payara.micro.create.project',
 			() => payaraMicroProjectGenerator.createProject()
+		)
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			'payara.server.maven.refresh.all',
+			() => {
+				for (let payaraServerMaven of payaraServerMavenInstanceProvider.getServerMavenInstances()) {
+					payaraServerMavenTree.refresh(payaraServerMaven);
+				}
+			}
+		)
+	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			'payara.server.maven.refresh',
+			payaraServerMaven => {
+				payaraServerMavenTree.refresh(payaraServerMaven);
+			}
+		)
+	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			'payara.server.maven.start',
+			payaraServerMaven => payaraServerMavenInstanceController.startServerMaven(payaraServerMaven, false)
+		)
+	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			'payara.server.maven.start.debug',
+			payaraServerMaven => payaraServerMavenInstanceController.startServerMaven(payaraServerMaven, true)
+		)
+	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			'payara.server.maven.start.dev',
+			payaraServerMaven => payaraServerMavenInstanceController.devServerMaven(payaraServerMaven, false)
+		)
+	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			'payara.server.maven.start.dev.debug',
+			payaraServerMaven => payaraServerMavenInstanceController.devServerMaven(payaraServerMaven, true)
+		)
+	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			'payara.server.maven.stop',
+			payaraServerMaven => payaraServerMavenInstanceController.stopServerMaven(payaraServerMaven)
+		)
+	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			'payara.server.maven.jdk.home',
+			payaraServerMaven => payaraServerMavenInstanceController.updateJDKHome(payaraServerMaven)
+		)
+	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			'payara.server.maven.deploy.settings',
+			payaraServerMaven => payaraServerMavenInstanceController.deploySettings(payaraServerMaven)
 		)
 	);
 
@@ -377,6 +467,20 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 		}
 
 	}
+
+	vscode.workspace.onDidSaveTextDocument((document: vscode.TextDocument) => {
+		const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
+		if (workspaceFolder) {
+			let fileName = path.basename(document.uri.fsPath);
+			if (fileName === "pom.xml") {
+				for (let payaraServerMaven of payaraServerMavenInstanceProvider.getServerMavenInstances()) {
+					if (workspaceFolder.uri === payaraServerMaven.getPath()) {
+						payaraServerMaven.getBuild().readBuildConfig();
+					}
+				}
+			}
+		}
+	});
 
 }
 

--- a/src/main/extension.ts
+++ b/src/main/extension.ts
@@ -111,7 +111,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	context.subscriptions.push(
 		vscode.window.registerWebviewViewProvider(
 			PayaraAIChatViewProvider.viewType,
-			payaraAiChatProvider
+			payaraAiChatProvider,
+			{ webviewOptions: { retainContextWhenHidden: true } }
 		)
 	);
 	context.subscriptions.push(

--- a/src/main/fish/payara/ai/AIModelFetcher.ts
+++ b/src/main/fish/payara/ai/AIModelFetcher.ts
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+'use strict';
+
+import * as vscode from 'vscode';
+import * as https from 'https';
+import * as http from 'http';
+import { URL } from 'url';
+
+interface RequestOptions {
+    hostname: string;
+    port: number;
+    path: string;
+    method: string;
+    headers: Record<string, string>;
+    protocol: string;
+}
+
+// Curated model lists for cloud providers — no network call or API key required.
+export const CLOUD_MODELS: Record<string, string[]> = {
+    OPEN_AI: [
+        'o3', 'o3-mini', 'o4-mini', 'o1', 'o1-mini',
+        'gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'gpt-4', 'gpt-3.5-turbo',
+    ],
+    ANTHROPIC: [
+        'claude-opus-4-5', 'claude-sonnet-4-5', 'claude-haiku-4-5',
+        'claude-3-5-sonnet-20241022', 'claude-3-5-haiku-20241022',
+        'claude-3-opus-20240229', 'claude-3-sonnet-20240229', 'claude-3-haiku-20240307',
+    ],
+    GOOGLE: [
+        'gemini-2.5-pro', 'gemini-2.0-flash', 'gemini-2.0-flash-exp',
+        'gemini-1.5-pro', 'gemini-1.5-flash', 'gemini-1.0-pro',
+    ],
+    GROQ: [
+        'llama-3.3-70b-versatile', 'llama-3.1-70b-versatile', 'llama-3.1-8b-instant',
+        'llama3-70b-8192', 'llama3-8b-8192', 'mixtral-8x7b-32768', 'gemma2-9b-it',
+    ],
+    MISTRAL: [
+        'mistral-large-latest', 'mistral-medium-latest', 'mistral-small-latest',
+        'codestral-latest', 'open-mixtral-8x22b', 'open-mixtral-8x7b', 'open-mistral-7b',
+    ],
+    DEEPSEEK: [
+        'deepseek-chat', 'deepseek-coder', 'deepseek-reasoner',
+    ],
+    DEEPINFRA: [
+        'meta-llama/Meta-Llama-3.1-70B-Instruct', 'meta-llama/Meta-Llama-3.1-8B-Instruct',
+        'mistralai/Mistral-7B-Instruct-v0.3', 'microsoft/WizardLM-2-8x22B',
+        'Qwen/Qwen2-72B-Instruct',
+    ],
+};
+
+const LOCAL_PROVIDERS = new Set(['OLLAMA', 'LM_STUDIO', 'GPT4ALL']);
+
+function fetchJson(options: RequestOptions): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const requester = options.protocol === 'https:' ? https : http;
+        const req = requester.request(
+            {
+                hostname: options.hostname,
+                port: options.port,
+                path: options.path,
+                method: options.method,
+                headers: options.headers,
+                timeout: 15000
+            },
+            (res) => {
+                let data = '';
+                res.on('data', (chunk) => { data += chunk; });
+                res.on('end', () => {
+                    if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+                        resolve(data);
+                    } else {
+                        let detail = '';
+                        try { detail = JSON.parse(data)?.error?.message || data.slice(0, 200); } catch { detail = data.slice(0, 200); }
+                        reject(new Error(`HTTP ${res.statusCode}${detail ? ': ' + detail : ''}`));
+                    }
+                });
+            }
+        );
+        req.on('timeout', () => { req.destroy(); reject(new Error('Request timed out')); });
+        req.on('error', (err) => reject(err));
+        req.end();
+    });
+}
+
+function buildLocalRequestOptions(provider: string, providerLocation: string): RequestOptions {
+    let baseUrl: string;
+    let path: string;
+    const headers: Record<string, string> = { 'Accept': 'application/json' };
+
+    switch (provider) {
+        case 'OLLAMA':
+            baseUrl = providerLocation || 'http://localhost:11434';
+            path = '/api/tags'; break;
+        case 'LM_STUDIO':
+            baseUrl = providerLocation || 'http://localhost:1234';
+            path = '/v1/models'; break;
+        default: // GPT4ALL
+            baseUrl = providerLocation || 'http://localhost:4891';
+            path = '/v1/models'; break;
+    }
+
+    const parsed = new URL(baseUrl);
+    const protocol = parsed.protocol;
+    const hostname = parsed.hostname;
+    const port = parsed.port ? parseInt(parsed.port, 10) : protocol === 'https:' ? 443 : 80;
+    const basePath = parsed.pathname.replace(/\/$/, '');
+    return { hostname, port, path: basePath + path, method: 'GET', headers, protocol };
+}
+
+function parseLocalModelIds(provider: string, body: string): string[] {
+    const json = JSON.parse(body);
+    if (provider === 'OLLAMA') {
+        const models: Array<{ name: string }> = json.models || [];
+        return models.map((m) => m.name).filter(Boolean);
+    }
+    const data: Array<{ id: string }> = json.data || [];
+    return data.map((m) => m.id).filter(Boolean);
+}
+
+export async function selectAIModel(): Promise<void> {
+    const config = vscode.workspace.getConfiguration();
+    const provider: string = config.get<string>('payara.ai.provider') || 'OPEN_AI';
+    const providerLocation: string = config.get<string>('payara.ai.providerLocation') || '';
+
+    const qp = vscode.window.createQuickPick();
+    qp.placeholder = `Select model for ${provider} (or type a custom name and press Enter)`;
+    qp.busy = true;
+    qp.ignoreFocusOut = true;
+    qp.show();
+
+    let fetchError: string | undefined;
+    try {
+        let modelIds: string[];
+
+        if (LOCAL_PROVIDERS.has(provider)) {
+            const opts = buildLocalRequestOptions(provider, providerLocation);
+            const body = await fetchJson(opts);
+            modelIds = parseLocalModelIds(provider, body);
+        } else if (provider === 'CUSTOM_OPEN_AI') {
+            const parsed = new URL(providerLocation);
+            const protocol = parsed.protocol;
+            const hostname = parsed.hostname;
+            const port = parsed.port ? parseInt(parsed.port, 10) : protocol === 'https:' ? 443 : 80;
+            const basePath = parsed.pathname.replace(/\/$/, '');
+            const opts: RequestOptions = { hostname, port, path: basePath + '/v1/models', method: 'GET', headers: { 'Accept': 'application/json' }, protocol };
+            const body = await fetchJson(opts);
+            const json = JSON.parse(body);
+            modelIds = (json.data as Array<{ id: string }> || []).map((m) => m.id).filter(Boolean);
+        } else {
+            // Cloud providers: use curated static list — no network call needed.
+            modelIds = CLOUD_MODELS[provider] || [];
+        }
+
+        modelIds.sort((a, b) => a.localeCompare(b));
+        qp.items = modelIds.map(id => ({ label: id }));
+    } catch (err: unknown) {
+        fetchError = err instanceof Error ? err.message : String(err);
+    }
+    qp.busy = false;
+
+    if (fetchError) {
+        qp.hide();
+        qp.dispose();
+        vscode.window.showErrorMessage(`Failed to fetch ${provider} models: ${fetchError}`);
+        return;
+    }
+
+    if (qp.items.length === 0) {
+        qp.hide();
+        qp.dispose();
+        vscode.window.showErrorMessage(`No models found for ${provider}.`);
+        return;
+    }
+
+    await new Promise<void>((resolve) => {
+        qp.onDidAccept(() => {
+            const modelName = qp.selectedItems[0]?.label || qp.value;
+            if (modelName) {
+                const target = vscode.workspace.workspaceFolders
+                    ? vscode.ConfigurationTarget.Workspace
+                    : vscode.ConfigurationTarget.Global;
+                vscode.workspace.getConfiguration().update('payara.ai.model', modelName, target);
+                vscode.window.showInformationMessage(`AI model set to: ${modelName}`);
+            }
+            qp.hide();
+            resolve();
+        });
+        qp.onDidHide(() => resolve());
+    });
+    qp.dispose();
+}

--- a/src/main/fish/payara/ai/PayaraAIChatViewProvider.ts
+++ b/src/main/fish/payara/ai/PayaraAIChatViewProvider.ts
@@ -1,0 +1,343 @@
+/*
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+'use strict';
+
+import * as vscode from 'vscode';
+import { PayaraServerMavenInstance } from '../server/maven/PayaraServerMavenInstance';
+
+export class PayaraAIChatViewProvider implements vscode.WebviewViewProvider {
+
+    public static readonly viewType = 'payara.ai.chat';
+
+    // Markers emitted by the Payara Server Maven Plugin to delimit AI responses in stdout.
+    public static readonly AI_RESPONSE_START = '%%PAYARA-AI-START%%';
+    public static readonly AI_RESPONSE_END = '%%PAYARA-AI-END%%';
+
+    private _view?: vscode.WebviewView;
+    private _instance?: PayaraServerMavenInstance;
+
+    // Rolling stdout buffer used to detect split markers across data chunks.
+    private _stdoutBuf = '';
+    private _inResponse = false;
+    private _responseBuf = '';
+
+    constructor(private readonly _extensionUri: vscode.Uri) {}
+
+    public resolveWebviewView(
+        webviewView: vscode.WebviewView,
+        _context: vscode.WebviewViewResolveContext,
+        _token: vscode.CancellationToken
+    ): void {
+        this._view = webviewView;
+        webviewView.webview.options = { enableScripts: true };
+        webviewView.webview.html = this._buildHtml(webviewView.webview);
+        webviewView.webview.onDidReceiveMessage(msg => {
+            if (msg.type === 'ready') {
+                // WebView JS is live — safe to send the current server state now.
+                this._post({ type: 'status', running: this._instance?.isStarted() === true });
+            } else if (msg.type === 'send') {
+                this._sendToAgent(msg.text);
+            }
+        });
+    }
+
+    /** Called by the controller when the Maven process reports the server is running. */
+    public onInstanceStarted(instance: PayaraServerMavenInstance): void {
+        this._instance = instance;
+        this._resetBuffers();
+        this._post({ type: 'status', running: true });
+    }
+
+    /** Called by the controller when the Maven process exits or errors. */
+    public onInstanceStopped(): void {
+        this._instance = undefined;
+        this._resetBuffers();
+        this._post({ type: 'status', running: false });
+    }
+
+    /**
+     * Called by the controller for every chunk of Maven process stdout/stderr.
+     * Scans for %%PAYARA-AI-START%% / %%PAYARA-AI-END%% delimiters and forwards
+     * the enclosed text to the WebView as an AI response message.
+     */
+    public handleData(data: string): void {
+        this._stdoutBuf += data;
+
+        while (true) {
+            if (!this._inResponse) {
+                const startIdx = this._stdoutBuf.indexOf(PayaraAIChatViewProvider.AI_RESPONSE_START);
+                if (startIdx === -1) {
+                    // Retain a trailing window in case the marker is split across chunks.
+                    const keep = PayaraAIChatViewProvider.AI_RESPONSE_START.length - 1;
+                    if (this._stdoutBuf.length > keep) {
+                        this._stdoutBuf = this._stdoutBuf.slice(-keep);
+                    }
+                    break;
+                }
+                const afterMarker = startIdx + PayaraAIChatViewProvider.AI_RESPONSE_START.length;
+                const nlIdx = this._stdoutBuf.indexOf('\n', afterMarker);
+                if (nlIdx === -1) { break; } // wait for the newline after the start marker
+                this._stdoutBuf = this._stdoutBuf.slice(nlIdx + 1);
+                this._inResponse = true;
+                this._responseBuf = '';
+            } else {
+                const endIdx = this._stdoutBuf.indexOf(PayaraAIChatViewProvider.AI_RESPONSE_END);
+                if (endIdx === -1) {
+                    const keep = PayaraAIChatViewProvider.AI_RESPONSE_END.length - 1;
+                    if (this._stdoutBuf.length > keep) {
+                        this._responseBuf += this._stdoutBuf.slice(0, this._stdoutBuf.length - keep);
+                        this._stdoutBuf = this._stdoutBuf.slice(this._stdoutBuf.length - keep);
+                    }
+                    break;
+                }
+                this._responseBuf += this._stdoutBuf.slice(0, endIdx);
+                this._stdoutBuf = this._stdoutBuf.slice(endIdx + PayaraAIChatViewProvider.AI_RESPONSE_END.length);
+                this._inResponse = false;
+                this._post({ type: 'response', text: this._responseBuf.trim() });
+                this._responseBuf = '';
+            }
+        }
+    }
+
+    private _sendToAgent(text: string): void {
+        if (!this._instance?.isStarted()) {
+            this._post({ type: 'error', text: 'Payara Server Maven is not running.' });
+            return;
+        }
+        this._instance.sendCommand(text);
+    }
+
+    private _resetBuffers(): void {
+        this._stdoutBuf = '';
+        this._inResponse = false;
+        this._responseBuf = '';
+    }
+
+    private _post(message: unknown): void {
+        this._view?.webview.postMessage(message);
+    }
+
+    private _nonce(): string {
+        const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+        let n = '';
+        for (let i = 0; i < 32; i++) {
+            n += chars.charAt(Math.floor(Math.random() * chars.length));
+        }
+        return n;
+    }
+
+    private _buildHtml(webview: vscode.Webview): string {
+        const nonce = this._nonce();
+        return /* html */`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: var(--vscode-font-family);
+    font-size: var(--vscode-font-size);
+    color: var(--vscode-foreground);
+    background: var(--vscode-editor-background);
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    overflow: hidden;
+  }
+  #messages {
+    flex: 1;
+    overflow-y: auto;
+    padding: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .msg {
+    padding: 6px 10px;
+    border-radius: 4px;
+    max-width: 92%;
+    word-break: break-word;
+    white-space: pre-wrap;
+    line-height: 1.45;
+  }
+  .user {
+    background: var(--vscode-inputOption-activeBackground);
+    align-self: flex-end;
+    border-radius: 8px 8px 2px 8px;
+  }
+  .agent {
+    background: var(--vscode-editor-selectionBackground);
+    align-self: flex-start;
+    border-radius: 8px 8px 8px 2px;
+  }
+  .system {
+    color: var(--vscode-descriptionForeground);
+    font-style: italic;
+    font-size: 0.85em;
+    align-self: center;
+    padding: 2px 8px;
+  }
+  #footer {
+    border-top: 1px solid var(--vscode-panel-border);
+    padding: 6px 8px 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  #input-row { display: flex; gap: 6px; align-items: flex-end; }
+  #input {
+    flex: 1;
+    resize: none;
+    background: var(--vscode-input-background);
+    color: var(--vscode-input-foreground);
+    border: 1px solid var(--vscode-input-border, transparent);
+    border-radius: 3px;
+    padding: 5px 7px;
+    font-family: inherit;
+    font-size: inherit;
+    min-height: 52px;
+    max-height: 120px;
+    overflow-y: auto;
+  }
+  #input:focus { outline: none; border-color: var(--vscode-focusBorder); }
+  #input::placeholder { color: var(--vscode-input-placeholderForeground); }
+  #send {
+    background: var(--vscode-button-background);
+    color: var(--vscode-button-foreground);
+    border: none;
+    border-radius: 3px;
+    padding: 0 12px;
+    height: 28px;
+    cursor: pointer;
+    font-size: inherit;
+  }
+  #send:hover:not(:disabled) { background: var(--vscode-button-hoverBackground); }
+  #send:disabled { opacity: 0.45; cursor: not-allowed; }
+  #status-bar { display: flex; align-items: center; gap: 5px; font-size: 0.75em; color: var(--vscode-descriptionForeground); }
+  #dot { width: 7px; height: 7px; border-radius: 50%; background: var(--vscode-errorForeground); flex-shrink: 0; }
+  #dot.on { background: #4caf50; }
+  .agent pre { background: var(--vscode-textBlockQuote-background, rgba(127,127,127,0.1)); border-left: 3px solid var(--vscode-textBlockQuote-border, #888); border-radius: 0 3px 3px 0; padding: 6px 8px; margin: 4px 0; overflow-x: auto; font-family: var(--vscode-editor-font-family, monospace); font-size: 0.9em; white-space: pre; }
+</style>
+</head>
+<body>
+<div id="messages">
+  <div class="msg system">Start Payara Server Maven with AI agent enabled to begin chatting.</div>
+</div>
+<div id="footer">
+  <div id="input-row">
+    <textarea id="input" placeholder="Ask the Payara AI agent… (Shift+Enter for new line)" rows="3" disabled></textarea>
+    <button id="send" disabled>Send</button>
+  </div>
+  <div id="status-bar"><div id="dot"></div><span id="status-text">Not connected</span></div>
+</div>
+<script nonce="${nonce}">
+const vscode = acquireVsCodeApi();
+const messagesEl = document.getElementById('messages');
+const inputEl    = document.getElementById('input');
+const sendBtn    = document.getElementById('send');
+const statusText = document.getElementById('status-text');
+const dotEl      = document.getElementById('dot');
+let running = false;
+
+function addMsg(text, cls) {
+  const div = document.createElement('div');
+  div.className = 'msg ' + cls;
+  if (cls === 'agent') {
+    const BT3 = '\\x60\\x60\\x60';
+    const lines = text.split('\\n');
+    let inCode = false;
+    let buf = [];
+    const flush = function(asCode) {
+      if (!buf.length) { return; }
+      if (asCode) {
+        const pre = document.createElement('pre');
+        const code = document.createElement('code');
+        code.textContent = buf.join('\\n');
+        pre.appendChild(code); div.appendChild(pre);
+      } else {
+        const s = document.createElement('span');
+        s.textContent = buf.join('\\n');
+        div.appendChild(s);
+      }
+      buf = [];
+    };
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i].replace(/\\r$/, '');
+      if (line.startsWith(BT3)) { flush(inCode); inCode = !inCode; }
+      else { buf.push(line); }
+    }
+    flush(inCode);
+  } else {
+    div.textContent = text;
+  }
+  messagesEl.appendChild(div);
+  messagesEl.scrollTop = messagesEl.scrollHeight;
+}
+
+function syncSendBtn() {
+  sendBtn.disabled = !running || !inputEl.value.trim();
+}
+
+function doSend() {
+  const text = inputEl.value.trim();
+  if (!text || !running) { return; }
+  addMsg(text, 'user');
+  vscode.postMessage({ type: 'send', text });
+  inputEl.value = '';
+  sendBtn.disabled = true;
+  statusText.textContent = 'Waiting for response…';
+}
+
+sendBtn.addEventListener('click', doSend);
+inputEl.addEventListener('keydown', e => {
+  if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); doSend(); }
+});
+inputEl.addEventListener('input', syncSendBtn);
+
+window.addEventListener('message', e => {
+  const msg = e.data;
+  switch (msg.type) {
+    case 'status':
+      running = msg.running;
+      dotEl.className = running ? 'on' : '';
+      inputEl.disabled = !running;
+      statusText.textContent = running ? 'Connected to Payara AI Agent' : 'Not connected';
+      syncSendBtn();
+      break;
+    case 'response':
+      addMsg(msg.text, 'agent');
+      statusText.textContent = running ? 'Connected to Payara AI Agent' : 'Not connected';
+      syncSendBtn();
+      break;
+    case 'error':
+      addMsg(msg.text, 'system');
+      syncSendBtn();
+      break;
+  }
+});
+
+// Notify the extension that the event listener is registered and we can receive messages.
+vscode.postMessage({ type: 'ready' });
+</script>
+</body>
+</html>`;
+    }
+
+}

--- a/src/main/fish/payara/ai/PayaraAIChatViewProvider.ts
+++ b/src/main/fish/payara/ai/PayaraAIChatViewProvider.ts
@@ -18,6 +18,7 @@
 'use strict';
 
 import * as vscode from 'vscode';
+import * as http from 'http';
 import { PayaraServerMavenInstance } from '../server/maven/PayaraServerMavenInstance';
 
 export class PayaraAIChatViewProvider implements vscode.WebviewViewProvider {
@@ -30,6 +31,11 @@ export class PayaraAIChatViewProvider implements vscode.WebviewViewProvider {
 
     private _view?: vscode.WebviewView;
     private _instance?: PayaraServerMavenInstance;
+
+    private _agentBaseUrl?: string;  // e.g. "http://localhost:PORT"
+    private _streamUrl?: string;
+    private _sseRequest?: http.ClientRequest;
+    private _sseBuf = '';
 
     // Rolling stdout buffer used to detect split markers across data chunks.
     private _stdoutBuf = '';
@@ -48,10 +54,11 @@ export class PayaraAIChatViewProvider implements vscode.WebviewViewProvider {
         webviewView.webview.html = this._buildHtml(webviewView.webview);
         webviewView.webview.onDidReceiveMessage(msg => {
             if (msg.type === 'ready') {
-                // WebView JS is live — safe to send the current server state now.
                 this._post({ type: 'status', running: this._instance?.isStarted() === true });
             } else if (msg.type === 'send') {
                 this._sendToAgent(msg.text);
+            } else if (msg.type === 'chart-disconnect') {
+                this._stopChart(msg.chartId);
             }
         });
     }
@@ -67,6 +74,7 @@ export class PayaraAIChatViewProvider implements vscode.WebviewViewProvider {
     public onInstanceStopped(): void {
         this._instance = undefined;
         this._resetBuffers();
+        this._disconnectFromStream();
         this._post({ type: 'status', running: false });
     }
 
@@ -76,6 +84,18 @@ export class PayaraAIChatViewProvider implements vscode.WebviewViewProvider {
      * the enclosed text to the WebView as an AI response message.
      */
     public handleData(data: string): void {
+        // Detect the SSE stream URL emitted once by the agent at startup.
+        const SU = '%%PAYARA-AI-STREAM-URL%%';
+        let si = 0, su: number;
+        while ((su = data.indexOf(SU, si)) !== -1) {
+            const after = su + SU.length;
+            const end = data.indexOf(SU, after);
+            if (end === -1) { break; }
+            const url = data.slice(after, end).trim();
+            if (url && !this._streamUrl) { this._connectToStream(url); }
+            si = end + SU.length;
+        }
+
         this._stdoutBuf += data;
 
         while (true) {
@@ -128,6 +148,99 @@ export class PayaraAIChatViewProvider implements vscode.WebviewViewProvider {
         this._responseBuf = '';
     }
 
+    private _stopChart(chartId: string): void {
+        if (!this._agentBaseUrl) { return; }
+        try {
+            const parsed = new URL(`${this._agentBaseUrl}/api/metrics/charts/${encodeURIComponent(chartId)}/stop`);
+            const req = http.request({
+                hostname: parsed.hostname,
+                port: parseInt(parsed.port || '80'),
+                path: parsed.pathname,
+                method: 'POST',
+                headers: { 'Content-Length': '0' }
+            }, () => {});
+            req.on('error', () => {});
+            req.end();
+        } catch (_) {}
+    }
+
+    private _connectToStream(url: string): void {
+        this._disconnectFromStream();
+        this._streamUrl = url;
+        try {
+            const parsed = new URL(url);
+            this._agentBaseUrl = `${parsed.protocol}//${parsed.hostname}:${parsed.port}`;
+            const req = http.request({
+                hostname: parsed.hostname,
+                port: parseInt(parsed.port || '80'),
+                path: parsed.pathname,
+                method: 'GET',
+                headers: { 'Accept': 'text/event-stream', 'Cache-Control': 'no-cache' }
+            }, (res) => {
+                res.setEncoding('utf8');
+                res.on('data', (chunk: string) => {
+                    this._sseBuf += chunk;
+                    this._processSseBuffer();
+                });
+                res.on('end', () => this._scheduleStreamReconnect());
+                res.on('error', () => this._scheduleStreamReconnect());
+            });
+            req.on('error', () => this._scheduleStreamReconnect());
+            req.end();
+            this._sseRequest = req;
+        } catch (_) {}
+    }
+
+    private _disconnectFromStream(): void {
+        if (this._sseRequest) {
+            try { this._sseRequest.destroy(); } catch (_) {}
+            this._sseRequest = undefined;
+        }
+        this._streamUrl = undefined;
+        this._agentBaseUrl = undefined;
+        this._sseBuf = '';
+    }
+
+    private _scheduleStreamReconnect(): void {
+        const url = this._streamUrl;
+        if (url && this._instance?.isStarted()) {
+            setTimeout(() => { if (this._instance?.isStarted()) { this._connectToStream(url); } }, 3000);
+        }
+    }
+
+    private _processSseBuffer(): void {
+        let pos: number;
+        while ((pos = this._sseBuf.indexOf('\n\n')) !== -1) {
+            const block = this._sseBuf.slice(0, pos);
+            this._sseBuf = this._sseBuf.slice(pos + 2);
+            this._handleSseEvent(block);
+        }
+    }
+
+    private _handleSseEvent(block: string): void {
+        let eventType = 'message';
+        let data = '';
+        for (const line of block.split('\n')) {
+            if (line.startsWith('event: ')) { eventType = line.slice(7).trim(); }
+            else if (line.startsWith('data: ')) { data += line.slice(6); }
+        }
+        if (!data) { return; }
+        try {
+            const json = JSON.parse(data.trim());
+            switch (eventType) {
+                case 'metric':
+                    this._post({ type: 'chart-data', chartId: json.chartId, point: json.point });
+                    break;
+                case 'chart-def':
+                    this._post({ type: 'chart-def', chartId: json.chartId, chartType: json.chartType, title: json.title, series: json.series });
+                    break;
+                case 'chart-remove':
+                    this._post({ type: 'chart-remove', chartId: json.chartId });
+                    break;
+            }
+        } catch (_) {}
+    }
+
     private _post(message: unknown): void {
         this._view?.webview.postMessage(message);
     }
@@ -164,6 +277,7 @@ export class PayaraAIChatViewProvider implements vscode.WebviewViewProvider {
   #messages {
     flex: 1;
     overflow-y: auto;
+    overflow-x: auto;
     padding: 8px;
     display: flex;
     flex-direction: column;
@@ -234,6 +348,13 @@ export class PayaraAIChatViewProvider implements vscode.WebviewViewProvider {
   #dot { width: 7px; height: 7px; border-radius: 50%; background: var(--vscode-errorForeground); flex-shrink: 0; }
   #dot.on { background: #4caf50; }
   .agent pre { background: var(--vscode-textBlockQuote-background, rgba(127,127,127,0.1)); border-left: 3px solid var(--vscode-textBlockQuote-border, #888); border-radius: 0 3px 3px 0; padding: 6px 8px; margin: 4px 0; overflow-x: auto; font-family: var(--vscode-editor-font-family, monospace); font-size: 0.9em; white-space: pre; }
+  .chart-card { background: var(--vscode-textBlockQuote-background, rgba(127,127,127,0.08)); border: 1px solid rgba(127,127,127,0.35); border-radius: 4px; padding: 6px 8px 4px; margin: 4px 0; width: 100%; min-width: 340px; box-sizing: border-box; }
+  .chart-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 3px; }
+  .chart-title { font-size: 0.8em; color: var(--vscode-descriptionForeground); }
+  .chart-stop-btn { font-size: 0.7em; background: transparent; color: var(--vscode-descriptionForeground); border: 1px solid rgba(127,127,127,0.5); border-radius: 2px; padding: 1px 6px; cursor: pointer; opacity: 0.7; flex-shrink: 0; }
+  .chart-stop-btn:hover:not(:disabled) { opacity: 1; color: var(--vscode-errorForeground); border-color: var(--vscode-errorForeground); }
+  .chart-stop-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+  .chart-card canvas { display: block; width: 100%; }
 </style>
 </head>
 <body>
@@ -256,34 +377,497 @@ const statusText = document.getElementById('status-text');
 const dotEl      = document.getElementById('dot');
 let running = false;
 
+// ── Chart rendering ──────────────────────────────────────────────────────────
+const liveCharts = {};
+
+function renderTextBlock(container, text) {
+  const BT3 = '\\x60\\x60\\x60';
+  const lines = text.split('\\n');
+  let inCode = false, buf = [];
+  const flush = function(asCode) {
+    if (!buf.length) { return; }
+    if (asCode) {
+      const pre = document.createElement('pre');
+      const code = document.createElement('code');
+      code.textContent = buf.join('\\n');
+      pre.appendChild(code); container.appendChild(pre);
+    } else {
+      const joined = buf.join('\\n');
+      if (joined.trim().length > 0) {
+        const s = document.createElement('span');
+        s.textContent = joined;
+        container.appendChild(s);
+      }
+    }
+    buf = [];
+  };
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].replace(/\\r$/, '');
+    if (line.startsWith(BT3)) { flush(inCode); inCode = !inCode; }
+    else { buf.push(line); }
+  }
+  flush(inCode);
+}
+
+function chartCssHeight(spec) {
+  var type = spec.type || 'line';
+  var ds = spec.live ? (spec.live.series || []) : (spec.static ? (spec.static.datasets || []) : []);
+  var n = ds.length || 1;
+  if (type === 'gauge') { return Math.max(160, 110 + Math.ceil(n / 3) * 110); }
+  if (type === 'sparkline') { return Math.max(80, n * 36 + 16); }
+  if (type === 'heatmap') { return Math.max(80, n * 28 + 24); }
+  if (type === 'stacked-area') { return 200; }
+  return 180;
+}
+
+function fmtVal(v) {
+  if (!isFinite(v)) { return '?'; }
+  if (Math.abs(v) >= 1e6) { return (v / 1e6).toFixed(1).replace(/\.0$/, '') + 'M'; }
+  if (Math.abs(v) >= 1e3) { return (v / 1e3).toFixed(1).replace(/\.0$/, '') + 'k'; }
+  if (Math.abs(v) < 10 && v !== Math.round(v)) { return v.toFixed(1); }
+  return Math.round(v).toString();
+}
+
+function niceTicks(maxVal, count) {
+  if (maxVal <= 0) { return [0, 1]; }
+  var raw = maxVal / count;
+  var mag = Math.pow(10, Math.floor(Math.log10(raw)));
+  var nice = [1, 2, 2.5, 5, 10].find(function(f) { return f * mag >= raw; }) || 10;
+  var step = nice * mag;
+  var ticks = [];
+  for (var t = 0; t <= maxVal * 1.001; t += step) {
+    ticks.push(Math.round(t * 1e9) / 1e9);
+    if (ticks.length > count + 1) { break; }
+  }
+  return ticks;
+}
+
+function renderChartBlock(container, spec) {
+  const card = document.createElement('div');
+  card.className = 'chart-card';
+  const header = document.createElement('div');
+  header.className = 'chart-header';
+  if (spec.title) {
+    const t = document.createElement('span');
+    t.className = 'chart-title';
+    t.textContent = spec.title;
+    header.appendChild(t);
+  }
+  const canvas = document.createElement('canvas');
+  var stopBtn = null;
+  if (spec.live && spec.live.chartId) {
+    stopBtn = document.createElement('button');
+    stopBtn.className = 'chart-stop-btn';
+    stopBtn.textContent = 'Disconnect';
+    (function(chartId, btn, cv) {
+      btn.addEventListener('click', function() {
+        btn.textContent = 'Stopped';
+        btn.disabled = true;
+        var ctx = cv.getContext('2d');
+        if (ctx) {
+          var dpr = window.devicePixelRatio || 1;
+          ctx.save(); ctx.scale(dpr, dpr);
+          ctx.fillStyle = 'rgba(128,128,128,0.35)';
+          ctx.fillRect(0, 0, cv.width / dpr, cv.height / dpr);
+          ctx.fillStyle = 'var(--vscode-descriptionForeground, #888)';
+          ctx.font = '10px var(--vscode-font-family, monospace)';
+          ctx.fillText('(disconnected)', 4, 14);
+          ctx.restore();
+        }
+        delete liveCharts[chartId];
+        vscode.postMessage({ type: 'chart-disconnect', chartId: chartId });
+      });
+    })(spec.live.chartId, stopBtn, canvas);
+    header.appendChild(stopBtn);
+  }
+  card.appendChild(header);
+  canvas.style.height = chartCssHeight(spec) + 'px';
+  card.appendChild(canvas);
+  container.appendChild(card);
+  setTimeout(function() {
+    var dpr = window.devicePixelRatio || 1;
+    var cssW = canvas.offsetWidth, cssH = canvas.offsetHeight;
+    canvas.width = Math.round(cssW * dpr);
+    canvas.height = Math.round(cssH * dpr);
+    if (spec.static) {
+      drawChart(canvas, spec.type || 'line', spec.static);
+    } else if (spec.live && spec.live.chartId) {
+      liveCharts[spec.live.chartId] = { canvas: canvas, spec: spec, points: [], timestamps: [], stopBtn: stopBtn };
+      drawWaiting(canvas);
+    }
+  }, 0);
+}
+
+function drawWaiting(canvas) {
+  const ctx = canvas.getContext('2d');
+  const dpr = window.devicePixelRatio || 1;
+  const W = canvas.width / dpr, H = canvas.height / dpr;
+  ctx.save(); ctx.scale(dpr, dpr);
+  ctx.fillStyle = 'rgba(127,127,127,0.55)';
+  ctx.font = '10px var(--vscode-font-family, monospace)';
+  ctx.textAlign = 'center';
+  ctx.fillText('Waiting for data…', W / 2, H / 2 + 3);
+  ctx.restore();
+}
+
+function updateLiveChart(chartId, point) {
+  const ch = liveCharts[chartId];
+  if (!ch) { return; }
+  ch.points.push(point);
+  var now = new Date();
+  ch.timestamps.push(now.getHours().toString().padStart(2,'0') + ':' + now.getMinutes().toString().padStart(2,'0') + ':' + now.getSeconds().toString().padStart(2,'0'));
+  if (ch.points.length > 60) { ch.points.shift(); ch.timestamps.shift(); }
+  const liveSeries = ch.spec.live.series || [];
+  const type = ch.spec.type || 'line';
+  const datasets = liveSeries.map(function(s) {
+    return { label: s.label, data: ch.points.map(function(p) { var v = p[s.label]; return (v === undefined || v === null) ? null : v; }), color: s.color, dashed: s.dashed };
+  });
+  const hasData = datasets.some(function(ds) { return ds.data.some(function(v) { return v !== null && v !== undefined; }); });
+  if (!hasData) { drawWaiting(ch.canvas); return; }
+  drawChart(ch.canvas, type, type === 'heatmap' ? { labels: ch.timestamps, datasets: datasets } : { datasets: datasets });
+}
+
+function drawChart(canvas, type, data) {
+  if (type === 'bar') { drawBarChart(canvas, data); }
+  else if (type === 'gauge') { drawGaugeChart(canvas, data); }
+  else if (type === 'sparkline') { drawSparklineChart(canvas, data); }
+  else if (type === 'stacked-area') { drawStackedAreaChart(canvas, data); }
+  else if (type === 'heatmap') { drawHeatmapChart(canvas, data); }
+  else { drawLineChart(canvas, data); }
+}
+
+function drawLineChart(canvas, data) {
+  const ctx = canvas.getContext('2d');
+  const dpr = window.devicePixelRatio || 1;
+  const TW = canvas.width / dpr, TH = canvas.height / dpr;
+  const AX = 36, LEG = 18;
+  const W = TW - AX, H = TH - LEG;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.save(); ctx.scale(dpr, dpr);
+  if (!data.datasets || !data.datasets.length) { ctx.restore(); return; }
+  const allVals = data.datasets.reduce(function(a, d) { return a.concat((d.data || []).filter(function(v) { return v !== null && v !== undefined; })); }, []);
+  const maxVal = Math.max.apply(null, allVals.concat([1]));
+  const n = (data.datasets[0].data || []).length;
+  if (n < 1) { ctx.restore(); return; }
+  const toX = function(i) { return AX + (n < 2 ? W / 2 : Math.round((i / (n - 1)) * (W - 1))); };
+  const toY = function(v) { return Math.round(H - (v / maxVal) * (H - 6)) + 3; };
+  // Y-axis ticks
+  const ticks = niceTicks(maxVal, 4);
+  ctx.font = '8px var(--vscode-font-family, monospace)';
+  ctx.fillStyle = 'rgba(127,127,127,0.55)';
+  ctx.textAlign = 'right';
+  ticks.forEach(function(t) {
+    const y = toY(t);
+    ctx.fillText(fmtVal(t), AX - 3, y + 3);
+    ctx.beginPath(); ctx.moveTo(AX, y); ctx.lineTo(AX + W, y);
+    ctx.strokeStyle = 'rgba(127,127,127,0.1)'; ctx.lineWidth = 0.5; ctx.stroke();
+  });
+  ctx.textAlign = 'left';
+  // Series
+  data.datasets.forEach(function(ds, di) {
+    const pts = ds.data || [];
+    if (!pts.length) { return; }
+    const validPts = pts.filter(function(v) { return v !== null && v !== undefined; });
+    if (!validPts.length) { return; }
+    if (!ds.dashed) {
+      ctx.beginPath();
+      var started = false;
+      pts.forEach(function(v, i) {
+        if (v === null || v === undefined) { started = false; return; }
+        if (!started) { ctx.moveTo(toX(i), toY(v)); started = true; } else { ctx.lineTo(toX(i), toY(v)); }
+      });
+      var lastValidIdx = pts.reduce(function(a, v, i) { return (v !== null && v !== undefined) ? i : a; }, 0);
+      ctx.lineTo(toX(lastValidIdx), H + LEG); ctx.lineTo(AX, H + LEG); ctx.closePath();
+      ctx.fillStyle = (ds.color || '#4caf50') + '28'; ctx.fill();
+    }
+    ctx.beginPath();
+    var lineStarted = false;
+    pts.forEach(function(v, i) {
+      if (v === null || v === undefined) { lineStarted = false; return; }
+      if (!lineStarted) { ctx.moveTo(toX(i), toY(v)); lineStarted = true; } else { ctx.lineTo(toX(i), toY(v)); }
+    });
+    ctx.strokeStyle = ds.color || '#4caf50'; ctx.lineWidth = 1.5;
+    ctx.setLineDash(ds.dashed ? [3, 3] : []); ctx.stroke(); ctx.setLineDash([]);
+    const latest = validPts[validPts.length - 1];
+    ctx.fillStyle = ds.color || '#4caf50';
+    ctx.font = '9px var(--vscode-font-family, monospace)';
+    ctx.fillText(ds.label + ': ' + (typeof latest === 'number' ? latest.toFixed(1) : String(latest)), AX + 2 + di * 120, TH - 3);
+  });
+  ctx.restore();
+}
+
+function drawBarChart(canvas, data) {
+  const ctx = canvas.getContext('2d');
+  const dpr = window.devicePixelRatio || 1;
+  const TW = canvas.width / dpr, TH = canvas.height / dpr;
+  const AX = 36, LEG = 18;
+  const W = TW - AX, H = TH - LEG;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.save(); ctx.scale(dpr, dpr);
+  if (!data.labels || !data.datasets || !data.datasets.length) { ctx.restore(); return; }
+  const n = data.labels.length;
+  const allVals = data.datasets.reduce(function(a, d) { return a.concat(d.data || []); }, []);
+  const maxVal = Math.max.apply(null, allVals.concat([1]));
+  // Y-axis ticks
+  const ticks = niceTicks(maxVal, 4);
+  ctx.font = '8px var(--vscode-font-family, monospace)'; ctx.textAlign = 'right';
+  ctx.fillStyle = 'rgba(127,127,127,0.55)';
+  ticks.forEach(function(t) {
+    const y = Math.round(H - (t / maxVal) * (H - 4)) + 3;
+    ctx.fillText(fmtVal(t), AX - 3, y + 3);
+    ctx.beginPath(); ctx.moveTo(AX, y); ctx.lineTo(AX + W, y);
+    ctx.strokeStyle = 'rgba(127,127,127,0.1)'; ctx.lineWidth = 0.5; ctx.stroke();
+  });
+  ctx.textAlign = 'left';
+  const groupW = (W - 2) / n;
+  const barW = Math.max(2, (groupW - 4) / data.datasets.length);
+  const colors = ['#4caf50', '#2196f3', '#ff9800', '#e53935'];
+  data.datasets.forEach(function(ds, di) {
+    ctx.fillStyle = ds.color || colors[di % colors.length];
+    (ds.data || []).forEach(function(v, i) {
+      const x = AX + 1 + i * groupW + di * barW;
+      const h = Math.round((v / maxVal) * (H - 4));
+      ctx.fillRect(x, H - h, barW - 1, h);
+    });
+  });
+  ctx.fillStyle = 'var(--vscode-descriptionForeground, #888)';
+  ctx.font = '9px var(--vscode-font-family, monospace)';
+  data.labels.forEach(function(lbl, i) { ctx.fillText(String(lbl).substring(0, 8), AX + 1 + i * groupW, TH - 3); });
+  ctx.restore();
+}
+function drawGaugeChart(canvas, data) {
+  const ctx = canvas.getContext('2d');
+  const dpr = window.devicePixelRatio || 1;
+  const W = canvas.width / dpr, H = canvas.height / dpr;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.save(); ctx.scale(dpr, dpr);
+  if (!data.datasets || !data.datasets.length) { ctx.restore(); return; }
+  // Solid series = values to chart; dashed series = reference max (not shown as its own gauge)
+  const solid = data.datasets.filter(function(ds) { return !ds.dashed; });
+  const dashed = data.datasets.filter(function(ds) { return ds.dashed; });
+  if (!solid.length) { ctx.restore(); return; }
+  const n = solid.length;
+  const slotW = W / n;
+  const r = Math.min(slotW * 0.38, H * 0.54);
+  const cy = Math.min(H * 0.65, r + 10);
+  // Global max fallback: max across all solid series latest values
+  const solidLatests = solid.map(function(ds) {
+    var pts = (ds.data || []).filter(function(v) { return v !== null && v !== undefined; });
+    return pts.length ? pts[pts.length - 1] : 0;
+  });
+  const globalMax = Math.max.apply(null, solidLatests.concat([1]));
+  // If there's a dashed reference series, use its latest value as the max
+  const refPts = dashed.length ? (dashed[0].data || []).filter(function(v) { return v !== null && v !== undefined; }) : [];
+  const refMax = refPts.length ? refPts[refPts.length - 1] : null;
+  const trackW = Math.max(4, Math.round(r * 0.22));
+  solid.forEach(function(ds, di) {
+    const pts = (ds.data || []).filter(function(v) { return v !== null && v !== undefined; });
+    if (!pts.length) { return; }
+    const latest = pts[pts.length - 1];
+    const maxVal = refMax !== null ? refMax : globalMax;
+    const pct = Math.min(1, Math.max(0, maxVal > 0 ? latest / maxVal : 0));
+    const color = ds.color || '#4caf50';
+    const gx = di * slotW + slotW / 2;
+    // Background track (full semicircle π → 2π)
+    ctx.beginPath();
+    ctx.arc(gx, cy, r, Math.PI, 2 * Math.PI);
+    ctx.strokeStyle = 'rgba(127,127,127,0.18)';
+    ctx.lineWidth = trackW; ctx.lineCap = 'round'; ctx.stroke();
+    // Value arc
+    if (pct > 0.01) {
+      ctx.beginPath();
+      ctx.arc(gx, cy, r, Math.PI, Math.PI + pct * Math.PI);
+      ctx.strokeStyle = color;
+      ctx.lineWidth = trackW; ctx.lineCap = 'round'; ctx.stroke();
+    }
+    // Value text
+    var fontSize = Math.max(9, Math.round(r * 0.32));
+    ctx.fillStyle = color;
+    ctx.font = 'bold ' + fontSize + 'px var(--vscode-font-family, monospace)';
+    ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+    ctx.fillText(typeof latest === 'number' ? latest.toFixed(1) : String(latest), gx, cy - r * 0.08);
+    // Percent text (small, below value)
+    var pctStr = Math.round(pct * 100) + '%';
+    ctx.font = Math.max(7, Math.round(r * 0.2)) + 'px var(--vscode-font-family, monospace)';
+    ctx.fillStyle = 'rgba(127,127,127,0.7)';
+    ctx.fillText(pctStr, gx, cy + r * 0.28);
+    // Label text below the arc
+    ctx.font = Math.max(8, Math.round(r * 0.2)) + 'px var(--vscode-font-family, monospace)';
+    ctx.fillStyle = 'var(--vscode-descriptionForeground, #888)';
+    ctx.fillText(ds.label, gx, cy + r * 0.62);
+  });
+  ctx.textAlign = 'left'; ctx.textBaseline = 'alphabetic';
+  ctx.restore();
+}
+function drawSparklineChart(canvas, data) {
+  const ctx = canvas.getContext('2d');
+  const dpr = window.devicePixelRatio || 1;
+  const W = canvas.width / dpr, H = canvas.height / dpr;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.save(); ctx.scale(dpr, dpr);
+  if (!data.datasets || !data.datasets.length) { ctx.restore(); return; }
+  const valid = data.datasets.filter(function(ds) {
+    return (ds.data || []).some(function(v) { return v !== null && v !== undefined; });
+  });
+  if (!valid.length) { ctx.restore(); return; }
+  const n = valid.length;
+  const valueColW = 68;
+  const plotW = W - valueColW;
+  const rowH = H / n;
+  // Shared scale across all series so rows are comparable
+  const allVals = valid.reduce(function(a, ds) {
+    return a.concat((ds.data || []).filter(function(v) { return v !== null && v !== undefined; }));
+  }, []);
+  const maxVal = Math.max.apply(null, allVals.concat([1]));
+  const minVal = Math.min.apply(null, allVals.concat([0]));
+  const range = maxVal - minVal || 1;
+  valid.forEach(function(ds, ri) {
+    const pts = ds.data || [];
+    const color = ds.color || '#4caf50';
+    const pad = 3;
+    const y0 = ri * rowH + pad, rH = rowH - pad * 2;
+    const m = pts.length;
+    const toX = function(i) { return m < 2 ? plotW / 2 : Math.round((i / (m - 1)) * (plotW - 1)); };
+    const toY = function(v) { return y0 + rH - ((v - minVal) / range) * rH; };
+    // Fill
+    ctx.beginPath();
+    var s = false, li = 0;
+    pts.forEach(function(v, i) {
+      if (v === null || v === undefined) { s = false; return; }
+      li = i;
+      if (!s) { ctx.moveTo(toX(i), toY(v)); s = true; } else { ctx.lineTo(toX(i), toY(v)); }
+    });
+    ctx.lineTo(toX(li), y0 + rH); ctx.lineTo(toX(0), y0 + rH); ctx.closePath();
+    ctx.fillStyle = color + '22'; ctx.fill();
+    // Line
+    ctx.beginPath(); s = false;
+    pts.forEach(function(v, i) {
+      if (v === null || v === undefined) { s = false; return; }
+      if (!s) { ctx.moveTo(toX(i), toY(v)); s = true; } else { ctx.lineTo(toX(i), toY(v)); }
+    });
+    ctx.strokeStyle = color; ctx.lineWidth = 1.2; ctx.setLineDash([]); ctx.stroke();
+    // Right-side label + value
+    const validPts = pts.filter(function(v) { return v !== null && v !== undefined; });
+    const latest = validPts.length ? validPts[validPts.length - 1] : null;
+    const midY = ri * rowH + rowH / 2 + 3;
+    ctx.fillStyle = color;
+    ctx.font = '8px var(--vscode-font-family, monospace)';
+    ctx.textAlign = 'left';
+    const valStr = latest !== null ? (typeof latest === 'number' ? latest.toFixed(1) : String(latest)) : '—';
+    ctx.fillText(ds.label + ': ' + valStr, plotW + 3, midY);
+  });
+  ctx.textAlign = 'left'; ctx.restore();
+}
+
+function drawStackedAreaChart(canvas, data) {
+  const ctx = canvas.getContext('2d');
+  const dpr = window.devicePixelRatio || 1;
+  const TW = canvas.width / dpr, TH = canvas.height / dpr;
+  const AX = 36, LEG = 18;
+  const W = TW - AX, H = TH - LEG;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.save(); ctx.scale(dpr, dpr);
+  if (!data.datasets || !data.datasets.length) { ctx.restore(); return; }
+  const n = (data.datasets[0].data || []).length;
+  if (n < 1) { ctx.restore(); return; }
+  const num = data.datasets.length;
+  const stacks = [], prev = new Array(n).fill(0);
+  for (var di = 0; di < num; di++) {
+    const pts = data.datasets[di].data || [];
+    const bottom = prev.slice(), top = prev.slice();
+    for (var i = 0; i < n; i++) {
+      const v = pts[i];
+      if (v !== null && v !== undefined) { top[i] = (top[i] || 0) + v; prev[i] = top[i]; }
+    }
+    stacks.push({ ds: data.datasets[di], bottom: bottom, top: top });
+  }
+  const maxVal = Math.max.apply(null, prev.concat([1]));
+  const toX = function(i) { return AX + (n < 2 ? W / 2 : Math.round((i / (n - 1)) * (W - 1))); };
+  const toY = function(v) { return Math.round(H - (v / maxVal) * (H - 6)) + 3; };
+  // Y-axis ticks
+  const ticks = niceTicks(maxVal, 4);
+  ctx.font = '8px var(--vscode-font-family, monospace)'; ctx.textAlign = 'right';
+  ctx.fillStyle = 'rgba(127,127,127,0.55)';
+  ticks.forEach(function(t) {
+    const y = toY(t);
+    ctx.fillText(fmtVal(t), AX - 3, y + 3);
+    ctx.beginPath(); ctx.moveTo(AX, y); ctx.lineTo(AX + W, y);
+    ctx.strokeStyle = 'rgba(127,127,127,0.1)'; ctx.lineWidth = 0.5; ctx.stroke();
+  });
+  ctx.textAlign = 'left';
+  stacks.forEach(function(s, si) {
+    const color = s.ds.color || '#4caf50';
+    ctx.beginPath();
+    s.top.forEach(function(v, i) { i === 0 ? ctx.moveTo(toX(i), toY(v)) : ctx.lineTo(toX(i), toY(v)); });
+    for (var i = n - 1; i >= 0; i--) { ctx.lineTo(toX(i), toY(s.bottom[i] || 0)); }
+    ctx.closePath(); ctx.fillStyle = color + '70'; ctx.fill();
+    ctx.beginPath();
+    s.top.forEach(function(v, i) { i === 0 ? ctx.moveTo(toX(i), toY(v)) : ctx.lineTo(toX(i), toY(v)); });
+    ctx.strokeStyle = color; ctx.lineWidth = 1.5; ctx.stroke();
+    const latest = s.top[n - 1] - (s.bottom[n - 1] || 0);
+    ctx.fillStyle = color; ctx.font = '9px var(--vscode-font-family, monospace)';
+    ctx.fillText(s.ds.label + ': ' + (typeof latest === 'number' ? latest.toFixed(1) : latest), AX + 2 + si * 120, TH - 3);
+  });
+  ctx.restore();
+}
+
+function drawHeatmapChart(canvas, data) {
+  const ctx = canvas.getContext('2d');
+  const dpr = window.devicePixelRatio || 1;
+  const W = canvas.width / dpr, H = canvas.height / dpr;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.save(); ctx.scale(dpr, dpr);
+  if (!data.datasets || !data.datasets.length || !data.labels || !data.labels.length) { ctx.restore(); return; }
+  const numCols = data.labels.length, numRows = data.datasets.length;
+  const labelW = 58, labelH = 14;
+  const cellW = (W - labelW) / numCols, cellH = (H - labelH) / numRows;
+  const allVals = data.datasets.reduce(function(a, ds) {
+    return a.concat((ds.data || []).filter(function(v) { return v !== null && v !== undefined && !isNaN(v); }));
+  }, []);
+  const minVal = Math.min.apply(null, allVals.concat([0]));
+  const maxVal = Math.max.apply(null, allVals.concat([1]));
+  const range = maxVal - minVal || 1;
+  data.datasets.forEach(function(ds, ri) {
+    (ds.data || []).forEach(function(val, ci) {
+      if (val === null || val === undefined || isNaN(val)) { return; }
+      const intensity = (val - minVal) / range;
+      ctx.fillStyle = heatColor(ds.color || '#4caf50', intensity);
+      ctx.fillRect(labelW + ci * cellW, ri * cellH, cellW - 1, cellH - 1);
+    });
+    ctx.fillStyle = 'var(--vscode-descriptionForeground, #888)';
+    ctx.font = '8px var(--vscode-font-family, monospace)';
+    ctx.textAlign = 'right';
+    ctx.fillText(ds.label.substring(0, 10), labelW - 2, ri * cellH + cellH / 2 + 3);
+  });
+  ctx.textAlign = 'center'; ctx.font = '7px var(--vscode-font-family, monospace)';
+  ctx.fillStyle = 'var(--vscode-descriptionForeground, #888)';
+  data.labels.forEach(function(lbl, ci) {
+    ctx.fillText(String(lbl).substring(0, 6), labelW + ci * cellW + cellW / 2, H - 2);
+  });
+  ctx.textAlign = 'left'; ctx.restore();
+}
+
+function heatColor(hex, intensity) {
+  var r = parseInt(hex.slice(1, 3), 16) || 76;
+  var g = parseInt(hex.slice(3, 5), 16) || 175;
+  var b = parseInt(hex.slice(5, 7), 16) || 80;
+  return 'rgba(' + r + ',' + g + ',' + b + ',' + (0.08 + intensity * 0.88).toFixed(2) + ')';
+}
+// ── End chart rendering ───────────────────────────────────────────────────────
+
 function addMsg(text, cls) {
   const div = document.createElement('div');
   div.className = 'msg ' + cls;
   if (cls === 'agent') {
-    const BT3 = '\\x60\\x60\\x60';
-    const lines = text.split('\\n');
-    let inCode = false;
-    let buf = [];
-    const flush = function(asCode) {
-      if (!buf.length) { return; }
-      if (asCode) {
-        const pre = document.createElement('pre');
-        const code = document.createElement('code');
-        code.textContent = buf.join('\\n');
-        pre.appendChild(code); div.appendChild(pre);
+    const parts = text.split('%%CHART%%');
+    parts.forEach(function(part, i) {
+      if (i % 2 === 0) {
+        renderTextBlock(div, part);
       } else {
-        const s = document.createElement('span');
-        s.textContent = buf.join('\\n');
-        div.appendChild(s);
+        try { renderChartBlock(div, JSON.parse(part.trim())); }
+        catch (_) { renderTextBlock(div, part); }
       }
-      buf = [];
-    };
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i].replace(/\\r$/, '');
-      if (line.startsWith(BT3)) { flush(inCode); inCode = !inCode; }
-      else { buf.push(line); }
-    }
-    flush(inCode);
+    });
   } else {
     div.textContent = text;
   }
@@ -325,6 +909,24 @@ window.addEventListener('message', e => {
       addMsg(msg.text, 'agent');
       statusText.textContent = running ? 'Connected to Payara AI Agent' : 'Not connected';
       syncSendBtn();
+      break;
+    case 'chart-data':
+      updateLiveChart(msg.chartId, msg.point);
+      break;
+    case 'chart-remove':
+      var remCh = liveCharts[msg.chartId];
+      if (remCh) {
+        if (remCh.stopBtn) { remCh.stopBtn.textContent = 'Stopped'; remCh.stopBtn.disabled = true; }
+        var rCtx = remCh.canvas.getContext('2d');
+        if (rCtx) {
+          rCtx.fillStyle = 'rgba(128,128,128,0.35)';
+          rCtx.fillRect(0, 0, remCh.canvas.width, remCh.canvas.height);
+          rCtx.fillStyle = 'var(--vscode-descriptionForeground, #888)';
+          rCtx.font = '10px var(--vscode-font-family, monospace)';
+          rCtx.fillText('(stopped)', 4, 14);
+        }
+        delete liveCharts[msg.chartId];
+      }
       break;
     case 'error':
       addMsg(msg.text, 'system');

--- a/src/main/fish/payara/micro/PayaraMicroInstanceController.ts
+++ b/src/main/fish/payara/micro/PayaraMicroInstanceController.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Copyright (c) 2020-2022 Payara Foundation and/or its affiliates and others.
+ * Copyright (c) 2020-2026 Payara Foundation and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -99,6 +99,56 @@ export class PayaraMicroInstanceController extends PayaraInstanceController {
             return true;
         }
         return false;
+    }
+
+    public async devMicro(payaraMicro: PayaraMicroInstance, debug: boolean, callback?: (status: boolean) => any): Promise<void> {
+        if (!payaraMicro.isStopped()) {
+            vscode.window.showErrorMessage('Payara Micro instance already running.');
+            return;
+        }
+        let workspaceFolder = vscode.workspace.getWorkspaceFolder(payaraMicro.getPath());
+
+        let debugConfig: DebugConfiguration | undefined;
+        if (debug && workspaceFolder) {
+            let debugManager: DebugManager = new DebugManager();
+            debugConfig = debugManager.getPayaraConfig(workspaceFolder, debugManager.getDefaultMicroConfig());
+        }
+        try {
+            payaraMicro.setDebug(debug);
+            await payaraMicro.setState(InstanceState.LOADING);
+            let process = payaraMicro.getBuild()
+                .devPayaraMicro(debugConfig,
+                    async data => {
+                        if (!payaraMicro.isStarted()) {
+                            if (debugConfig && data.indexOf("Listening for transport dt_socket at address:") > -1) {
+                                vscode.debug.startDebugging(workspaceFolder, debugConfig);
+                                debugConfig = undefined;
+                            }
+                            if (this.parseApplicationUrl(data, payaraMicro)) {
+                                await payaraMicro.setState(InstanceState.RUNNING);
+                            }
+                        }
+                    },
+                    async (code) => {
+                        await payaraMicro.setState(InstanceState.STOPPED);
+                        if (code !== 0) {
+                            console.warn(`devMicro task failed with exit code ${code}`);
+                        }
+                    },
+                    async (error) => {
+                        vscode.window.showErrorMessage(`Error on executing devMicro task: ${error.message}`);
+                        await payaraMicro.setState(InstanceState.STOPPED);
+                    }
+                );
+            if (process) {
+                payaraMicro.setProcess(process);
+            } else {
+                await payaraMicro.setState(InstanceState.STOPPED);
+            }
+        } catch (error) {
+            vscode.window.showErrorMessage("Error on executing devMicro task:" + ((error instanceof Error)? error.message : error));
+            await payaraMicro.setState(InstanceState.STOPPED);
+        }
     }
 
     public async reloadMicro(payaraMicro: PayaraMicroInstance,

--- a/src/main/fish/payara/project/Build.ts
+++ b/src/main/fish/payara/project/Build.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Copyright (c) 2020 Payara Foundation and/or its affiliates and others.
+ * Copyright (c) 2020-2026 Payara Foundation and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -51,6 +51,13 @@ export interface Build {
         onError: (err: Error) => any
     ): ChildProcess | undefined;
 
+    devPayaraMicro(
+        debugConfig: DebugConfiguration | undefined,
+        onData: (data: string) => any,
+        onExit: (code: number) => any,
+        onError: (err: Error) => any
+    ): ChildProcess | undefined;
+
     reloadPayaraMicro(
         onExit: (code: number) => any,
         onError: (err: Error) => any,
@@ -64,6 +71,26 @@ export interface Build {
     ): ChildProcess | undefined;
 
     bundlePayaraMicro(
+        onExit: (code: number) => any,
+        onError: (err: Error) => any
+    ): ChildProcess | undefined;
+
+    startPayaraServerMaven(
+        debugConfig: DebugConfiguration | undefined,
+        onData: (data: string) => any,
+        onExit: (code: number) => any,
+        onError: (err: Error) => any
+    ): ChildProcess | undefined;
+
+    devPayaraServerMaven(
+        debugConfig: DebugConfiguration | undefined,
+        onData: (data: string) => any,
+        onExit: (code: number) => any,
+        onError: (err: Error) => any
+    ): ChildProcess | undefined;
+
+    stopPayaraServerMaven(
+        processId: number,
         onExit: (code: number) => any,
         onError: (err: Error) => any
     ): ChildProcess | undefined;

--- a/src/main/fish/payara/project/DebugManager.ts
+++ b/src/main/fish/payara/project/DebugManager.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Copyright (c) 2020 Payara Foundation and/or its affiliates and others.
+ * Copyright (c) 2020-2026 Payara Foundation and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -85,6 +85,16 @@ export class DebugManager {
             hostName: ServerUtils.DEFAULT_HOST,
             name: "payara-server",
             port: 9009
+        };
+    }
+
+    public getDefaultServerMavenConfig(): DebugConfiguration {
+        return {
+            type: "java",
+            request: "attach",
+            hostName: ServerUtils.DEFAULT_HOST,
+            name: "payara-server-maven",
+            port: 5005
         };
     }
 

--- a/src/main/fish/payara/project/Gradle.ts
+++ b/src/main/fish/payara/project/Gradle.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Copyright (c) 2020-2022 Payara Foundation and/or its affiliates and others.
+ * Copyright (c) 2020-2026 Payara Foundation and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -278,6 +278,16 @@ export class Gradle implements Build {
         throw new Error("Gradle project generator not supported yet.");
     }
 
+    public devPayaraMicro(
+        debugConfig: DebugConfiguration | undefined,
+        onData: (data: string) => any,
+        onExit: (code: number) => any,
+        onError: (err: Error) => any
+    ): ChildProcess | undefined {
+        vscode.window.showWarningMessage('The dev goal is not supported for Gradle projects.');
+        return undefined;
+    }
+
     public startPayaraMicro(
         debugConfig: DebugConfiguration | undefined,
         onData: (data: string) => any,
@@ -410,6 +420,35 @@ export class Gradle implements Build {
             command: `gradle ${PayaraMicroGradlePlugin.STOP_GOAL}`,
             group: "build"
         };
+    }
+
+    public startPayaraServerMaven(
+        debugConfig: DebugConfiguration | undefined,
+        onData: (data: string) => any,
+        onExit: (code: number) => any,
+        onError: (err: Error) => any
+    ): ChildProcess | undefined {
+        vscode.window.showWarningMessage('The payara-server-maven-plugin is not supported for Gradle projects.');
+        return undefined;
+    }
+
+    public devPayaraServerMaven(
+        debugConfig: DebugConfiguration | undefined,
+        onData: (data: string) => any,
+        onExit: (code: number) => any,
+        onError: (err: Error) => any
+    ): ChildProcess | undefined {
+        vscode.window.showWarningMessage('The payara-server-maven-plugin is not supported for Gradle projects.');
+        return undefined;
+    }
+
+    public stopPayaraServerMaven(
+        processId: number,
+        onExit: (code: number) => any,
+        onError: (err: Error) => any
+    ): ChildProcess | undefined {
+        vscode.window.showWarningMessage('The payara-server-maven-plugin is not supported for Gradle projects.');
+        return undefined;
     }
 
 }

--- a/src/main/fish/payara/project/Maven.ts
+++ b/src/main/fish/payara/project/Maven.ts
@@ -165,6 +165,22 @@ export class Maven implements Build {
         return mvnProcess;
     }
 
+    public registerKillOnExit(proc: ChildProcess): void {
+        const killTree = () => {
+            if (proc.pid && !proc.killed) {
+                try {
+                    if (JavaUtils.IS_WIN) {
+                        cp.execSync(`taskkill /F /T /PID ${proc.pid}`, { stdio: 'ignore' });
+                    } else {
+                        proc.kill('SIGTERM');
+                    }
+                } catch (_) { /* already gone */ }
+            }
+        };
+        process.on('exit', killTree);
+        proc.once('exit', () => process.removeListener('exit', killTree));
+    }
+
     public fireCommandInteractive(
         commands: string[],
         terminalName: string,
@@ -495,7 +511,9 @@ export class Maven implements Build {
         if (debugConfig) {
             commands.push(`-Ddebug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debugConfig.port}`);
         }
-        return this.fireCommand(commands, onData, onExit, onError);
+        const proc = this.fireCommand(commands, onData, onExit, onError);
+        this.registerKillOnExit(proc);
+        return proc;
 
     }
 
@@ -511,7 +529,9 @@ export class Maven implements Build {
         if (debugConfig) {
             commands.push(`-Ddebug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debugConfig.port}`);
         }
-        return this.fireCommand(commands, onData, onExit, onError);
+        const proc = this.fireCommand(commands, onData, onExit, onError);
+        this.registerKillOnExit(proc);
+        return proc;
     }
 
     public reloadPayaraMicro(

--- a/src/main/fish/payara/project/Maven.ts
+++ b/src/main/fish/payara/project/Maven.ts
@@ -228,6 +228,23 @@ export class Maven implements Build {
             exitCallback(code);
         });
 
+        // Kill the entire process tree (cmd.exe + Maven JVM + Payara JVM) when
+        // the Node.js extension host exits, so no orphaned server is left behind.
+        const killTree = () => {
+            if (mvnProcess.pid && !mvnProcess.killed) {
+                try {
+                    if (JavaUtils.IS_WIN) {
+                        cp.execSync(`taskkill /F /T /PID ${mvnProcess.pid}`, { stdio: 'ignore' });
+                    } else {
+                        mvnProcess.kill('SIGTERM');
+                    }
+                } catch (_) { /* already gone */ }
+            }
+        };
+        process.on('exit', killTree);
+        // Remove the listener once Maven exits normally to avoid accumulating stale listeners.
+        mvnProcess.once('exit', () => process.removeListener('exit', killTree));
+
         const pty: vscode.Pseudoterminal = {
             onDidWrite: writeEmitter.event,
             open: () => {
@@ -253,8 +270,14 @@ export class Maven implements Build {
                 }
             },
             close: () => {
-                if (!mvnProcess.killed) {
-                    mvnProcess.kill();
+                if (mvnProcess.pid && !mvnProcess.killed) {
+                    try {
+                        if (JavaUtils.IS_WIN) {
+                            cp.execSync(`taskkill /F /T /PID ${mvnProcess.pid}`, { stdio: 'ignore' });
+                        } else {
+                            mvnProcess.kill('SIGTERM');
+                        }
+                    } catch (_) { /* already gone */ }
                 }
                 writeEmitter.dispose();
             }
@@ -626,7 +649,7 @@ export class Maven implements Build {
         const config = vscode.workspace.getConfiguration();
         if (config.get<boolean>('payara.ai.agent') !== true) { return []; }
 
-        const flags: string[] = ['-Dpayara.ai.agent=true'];
+        const flags: string[] = ['-Dpayara.ai.agent=true', '-Dpayara.ai.chat.markers=true'];
 
         const str = (key: string, prop: string) => {
             const v = config.get<string>(key);

--- a/src/main/fish/payara/project/Maven.ts
+++ b/src/main/fish/payara/project/Maven.ts
@@ -207,13 +207,23 @@ export class Maven implements Build {
         });
 
         const handleData = (data: string | Buffer): void => {
-            const text = data.toString().replace(/\r?\n/g, '\r\n');
+            const raw = data.toString();
+            const filtered = raw
+                .split(/\r?\n/)
+                .filter(line => {
+                    const t = line.trim();
+                    return t !== '%%PAYARA-AI-START%%'
+                        && t !== '%%PAYARA-AI-END%%'
+                        && !t.startsWith('%%PAYARA-AI-STREAM-URL%%');
+                })
+                .join('\n')
+                .replace(/\n/g, '\r\n');
             if (terminalOpen) {
-                writeEmitter.fire(text);
+                writeEmitter.fire(filtered);
             } else {
-                outputBuffer.push(text);
+                outputBuffer.push(filtered);
             }
-            dataCallback(data.toString());
+            dataCallback(raw);
         };
 
         if (mvnProcess.stdout !== null) {

--- a/src/main/fish/payara/project/Maven.ts
+++ b/src/main/fish/payara/project/Maven.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Copyright (c) 2020-2024 Payara Foundation and/or its affiliates and others.
+ * Copyright (c) 2020-2026 Payara Foundation and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -33,6 +33,7 @@ import { PayaraServerTransformPlugin } from '../server/PayaraServerTransformPlug
 import { ProjectOutputWindowProvider } from './ProjectOutputWindowProvider';
 import { MavenMicroPluginReader } from './MavenMicroPluginReader';
 import { BuildReader } from './BuildReader';
+import { PayaraServerMavenPlugin } from '../server/maven/PayaraServerMavenPlugin';
 import { TaskManager } from './TaskManager';
 import { PayaraInstance } from '../common/PayaraInstance';
 import { DeployOption } from '../common/DeployOption';
@@ -365,6 +366,21 @@ export class Maven implements Build {
 
     }
 
+    public devPayaraMicro(
+        debugConfig: DebugConfiguration | undefined,
+        onData: (data: string) => any,
+        onExit: (code: number) => any,
+        onError: (err: Error) => any
+    ): ChildProcess | undefined {
+        let taskManager: TaskManager = new TaskManager();
+        let taskDefinition = taskManager.getPayaraConfig(this.workspaceFolder, this.getDefaultMicroDevConfig());
+        let commands = taskDefinition.command.split(/\s+/);
+        if (debugConfig) {
+            commands.push(`-Ddebug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debugConfig.port}`);
+        }
+        return this.fireCommand(commands, onData, onExit, onError);
+    }
+
     public reloadPayaraMicro(
         onExit: (code: number) => any,
         onError: (err: Error) => any,
@@ -433,6 +449,15 @@ export class Maven implements Build {
         };
     }
 
+    private getDefaultMicroDevConfig(): TaskDefinition {
+        return {
+            label: "payara-micro-dev",
+            type: "shell",
+            command: `mvn ${PayaraMicroMavenPlugin.GROUP_ID}:${PayaraMicroMavenPlugin.ARTIFACT_ID}:${PayaraMicroMavenPlugin.DEV_GOAL}`,
+            group: "build"
+        };
+    }
+
     private getDefaultMicroBundleConfig(): TaskDefinition {
         return {
             label: "payara-micro-bundle",
@@ -484,6 +509,77 @@ export class Maven implements Build {
             label: "payara-tranform",
             type: "shell",
             command: `mvn package ${PayaraServerTransformPlugin.GROUP_ID}:${PayaraServerTransformPlugin.ARTIFACT_ID}:${PayaraServerTransformPlugin.VERSION}:${PayaraServerTransformPlugin.RUN_GOAL}`,
+            group: "build"
+        };
+    }
+
+    public startPayaraServerMaven(
+        debugConfig: DebugConfiguration | undefined,
+        onData: (data: string) => any,
+        onExit: (code: number) => any,
+        onError: (err: Error) => any
+    ): ChildProcess | undefined {
+        let taskManager: TaskManager = new TaskManager();
+        let taskDefinition = taskManager.getPayaraConfig(this.workspaceFolder, this.getDefaultServerMavenStartConfig());
+        let commands = taskDefinition.command.split(/\s+/);
+        if (debugConfig) {
+            commands.push(`-Ddebug=true`);
+            commands.push(`-DdebugPort=${debugConfig.port}`);
+        }
+        return this.fireCommand(commands, onData, onExit, onError);
+    }
+
+    public devPayaraServerMaven(
+        debugConfig: DebugConfiguration | undefined,
+        onData: (data: string) => any,
+        onExit: (code: number) => any,
+        onError: (err: Error) => any
+    ): ChildProcess | undefined {
+        let taskManager: TaskManager = new TaskManager();
+        let taskDefinition = taskManager.getPayaraConfig(this.workspaceFolder, this.getDefaultServerMavenDevConfig());
+        let commands = taskDefinition.command.split(/\s+/);
+        if (debugConfig) {
+            commands.push(`-Dpayara.debug=true`);
+            commands.push(`-Dpayara.debug.port=${debugConfig.port}`);
+        }
+        return this.fireCommand(commands, onData, onExit, onError);
+    }
+
+    public stopPayaraServerMaven(
+        processId: number,
+        onExit: (code: number) => any,
+        onError: (err: Error) => any
+    ): ChildProcess | undefined {
+        let taskManager: TaskManager = new TaskManager();
+        let taskDefinition = taskManager.getPayaraConfig(this.workspaceFolder, this.getDefaultServerMavenStopConfig());
+        let commands = taskDefinition.command.split(/\s+/);
+        commands.push(`-DprocessId=${processId}`);
+        return this.fireCommand(commands, () => { }, onExit, onError);
+    }
+
+    private getDefaultServerMavenStartConfig(): TaskDefinition {
+        return {
+            label: "payara-server-maven-start",
+            type: "shell",
+            command: `mvn package ${PayaraServerMavenPlugin.GROUP_ID}:${PayaraServerMavenPlugin.ARTIFACT_ID}:${PayaraServerMavenPlugin.START_GOAL}`,
+            group: "build"
+        };
+    }
+
+    private getDefaultServerMavenDevConfig(): TaskDefinition {
+        return {
+            label: "payara-server-maven-dev",
+            type: "shell",
+            command: `mvn package ${PayaraServerMavenPlugin.GROUP_ID}:${PayaraServerMavenPlugin.ARTIFACT_ID}:${PayaraServerMavenPlugin.DEV_GOAL}`,
+            group: "build"
+        };
+    }
+
+    private getDefaultServerMavenStopConfig(): TaskDefinition {
+        return {
+            label: "payara-server-maven-stop",
+            type: "shell",
+            command: `mvn ${PayaraServerMavenPlugin.GROUP_ID}:${PayaraServerMavenPlugin.ARTIFACT_ID}:${PayaraServerMavenPlugin.STOP_GOAL}`,
             group: "build"
         };
     }

--- a/src/main/fish/payara/project/Maven.ts
+++ b/src/main/fish/payara/project/Maven.ts
@@ -165,6 +165,106 @@ export class Maven implements Build {
         return mvnProcess;
     }
 
+    public fireCommandInteractive(
+        commands: string[],
+        terminalName: string,
+        dataCallback: (data: string) => any,
+        exitCallback: (code: number) => any,
+        errorCallback: (err: Error) => any,
+        extraEnv?: Record<string, string>
+    ): ChildProcess {
+        if (commands.length <= 1) {
+            throw new Error(`Invalid command definition ${commands.join(" ")}`);
+        }
+
+        let mavenExe = commands[0];
+        let args = commands.splice(1, commands.length);
+
+        if (mavenExe === "mvnw") {
+            mavenExe = this.getWrapperFullPath();
+        } else {
+            mavenExe = this.getExecutableFullPath(undefined);
+        }
+
+        if (!this.workspaceFolder) {
+            throw new Error("WorkSpace path not found.");
+        }
+
+        let jdkHome: string | undefined;
+        let env = { ...process.env, ...extraEnv };
+        if (this.payaraInstance && (jdkHome = this.payaraInstance.getJDKHome())) {
+            env['JAVA_HOME'] = jdkHome;
+        }
+
+        const writeEmitter = new vscode.EventEmitter<string>();
+        const outputBuffer: string[] = [];
+        let terminalOpen = false;
+
+        const mvnProcess: ChildProcess = cp.spawn(mavenExe, args, {
+            cwd: this.workspaceFolder.uri.fsPath,
+            shell: true,
+            env: env
+        });
+
+        const handleData = (data: string | Buffer): void => {
+            const text = data.toString().replace(/\r?\n/g, '\r\n');
+            if (terminalOpen) {
+                writeEmitter.fire(text);
+            } else {
+                outputBuffer.push(text);
+            }
+            dataCallback(data.toString());
+        };
+
+        if (mvnProcess.stdout !== null) {
+            mvnProcess.stdout.on('data', handleData);
+        }
+        if (mvnProcess.stderr !== null) {
+            mvnProcess.stderr.on('data', handleData);
+        }
+        mvnProcess.on('error', errorCallback);
+        mvnProcess.on('exit', (code: number) => {
+            writeEmitter.fire(`\r\nProcess exited with code ${code}\r\n`);
+            exitCallback(code);
+        });
+
+        const pty: vscode.Pseudoterminal = {
+            onDidWrite: writeEmitter.event,
+            open: () => {
+                terminalOpen = true;
+                if (jdkHome) {
+                    writeEmitter.fire(`Java Platform: ${jdkHome}\r\n`);
+                }
+                writeEmitter.fire(`> ${mavenExe} ${args.join(' ')}\r\n`);
+                for (const chunk of outputBuffer) {
+                    writeEmitter.fire(chunk);
+                }
+                outputBuffer.length = 0;
+            },
+            handleInput: (data: string) => {
+                if (mvnProcess.stdin) {
+                    if (data === '\r') {
+                        mvnProcess.stdin.write('\n');
+                        writeEmitter.fire('\r\n');
+                    } else {
+                        mvnProcess.stdin.write(data);
+                        writeEmitter.fire(data);
+                    }
+                }
+            },
+            close: () => {
+                if (!mvnProcess.killed) {
+                    mvnProcess.kill();
+                }
+                writeEmitter.dispose();
+            }
+        };
+
+        vscode.window.createTerminal({ name: terminalName, pty }).show(false);
+
+        return mvnProcess;
+    }
+
     public getDefaultHome(): string | undefined {
         const config = vscode.workspace.getConfiguration();
         let mavenHome: string | undefined = config.get<string>('maven.home');
@@ -513,6 +613,63 @@ export class Maven implements Build {
         };
     }
 
+    private getAIAgentEnv(): Record<string, string> {
+        const config = vscode.workspace.getConfiguration();
+        if (config.get<boolean>('payara.ai.agent') !== true) { return {}; }
+        const env: Record<string, string> = {};
+        const apiKey = config.get<string>('payara.ai.apiKey');
+        if (apiKey) { env['PAYARA_AI_API_KEY'] = apiKey; }
+        return env;
+    }
+
+    private getAIAgentFlags(): string[] {
+        const config = vscode.workspace.getConfiguration();
+        if (config.get<boolean>('payara.ai.agent') !== true) { return []; }
+
+        const flags: string[] = ['-Dpayara.ai.agent=true'];
+
+        const str = (key: string, prop: string) => {
+            const v = config.get<string>(key);
+            if (v) { flags.push(`-D${prop}=${v}`); }
+        };
+        const num = (key: string, prop: string) => {
+            const v = config.get<number | null>(key);
+            if (v !== undefined && v !== null) { flags.push(`-D${prop}=${v}`); }
+        };
+        const bool = (key: string, prop: string) => {
+            if (config.get<boolean>(key) === true) { flags.push(`-D${prop}=true`); }
+        };
+
+        str('payara.ai.provider',         'payara.ai.provider');
+        str('payara.ai.model',            'payara.ai.model');
+        str('payara.ai.providerLocation', 'payara.ai.provider.location');
+        str('payara.ai.organizationId',   'payara.ai.organizationId');
+        str('payara.ai.customHeaders',    'payara.ai.customHeaders');
+
+        num('payara.ai.temperature',           'payara.ai.temperature');
+        num('payara.ai.topP',                  'payara.ai.topP');
+        num('payara.ai.topK',                  'payara.ai.topK');
+        num('payara.ai.maxTokens',             'payara.ai.maxTokens');
+        num('payara.ai.maxCompletionTokens',   'payara.ai.maxCompletionTokens');
+        num('payara.ai.maxOutputTokens',       'payara.ai.maxOutputTokens');
+        num('payara.ai.presencePenalty',       'payara.ai.presencePenalty');
+        num('payara.ai.frequencyPenalty',      'payara.ai.frequencyPenalty');
+        num('payara.ai.repeatPenalty',         'payara.ai.repeatPenalty');
+        num('payara.ai.seed',                  'payara.ai.seed');
+        num('payara.ai.timeout',               'payara.ai.timeout');
+        num('payara.ai.maxRetries',            'payara.ai.maxRetries');
+        num('payara.ai.chatHistoryLimit',      'payara.ai.chat.history.limit');
+
+        bool('payara.ai.stream',                    'payara.ai.stream');
+        bool('payara.ai.logRequests',               'payara.ai.log.requests');
+        bool('payara.ai.logResponses',              'payara.ai.log.responses');
+        bool('payara.ai.allowCodeExecution',        'payara.ai.allowCodeExecution');
+        bool('payara.ai.includeCodeExecutionOutput','payara.ai.includeCodeExecutionOutput');
+        bool('payara.ai.chatHistory',               'payara.ai.chat.history');
+
+        return flags;
+    }
+
     public startPayaraServerMaven(
         debugConfig: DebugConfiguration | undefined,
         onData: (data: string) => any,
@@ -526,7 +683,13 @@ export class Maven implements Build {
             commands.push(`-Ddebug=true`);
             commands.push(`-DdebugPort=${debugConfig.port}`);
         }
-        return this.fireCommand(commands, onData, onExit, onError);
+        commands.push(...this.getAIAgentFlags());
+        return this.fireCommandInteractive(
+            commands,
+            `Payara Server Maven - ${this.workspaceFolder.name}`,
+            onData, onExit, onError,
+            this.getAIAgentEnv()
+        );
     }
 
     public devPayaraServerMaven(
@@ -542,7 +705,13 @@ export class Maven implements Build {
             commands.push(`-Dpayara.debug=true`);
             commands.push(`-Dpayara.debug.port=${debugConfig.port}`);
         }
-        return this.fireCommand(commands, onData, onExit, onError);
+        commands.push(...this.getAIAgentFlags());
+        return this.fireCommandInteractive(
+            commands,
+            `Payara Server Maven - ${this.workspaceFolder.name}`,
+            onData, onExit, onError,
+            this.getAIAgentEnv()
+        );
     }
 
     public stopPayaraServerMaven(

--- a/src/main/fish/payara/project/MavenPomReader.ts
+++ b/src/main/fish/payara/project/MavenPomReader.ts
@@ -52,9 +52,9 @@ export class MavenPomReader implements BuildReader {
                     }
                     if (result.project) {
                         let project = result.project;
-                        reader.groupId = project.groupId[0];
-                        reader.artifactId = project.artifactId[0];
-                        reader.version = project.version[0];
+                        reader.groupId = project.groupId?.[0] ?? project.parent?.[0]?.groupId?.[0] ?? '';
+                        reader.artifactId = project.artifactId?.[0] ?? '';
+                        reader.version = project.version?.[0] ?? project.parent?.[0]?.version?.[0] ?? '';
                         reader.finalName = reader.parseFinalName(project.build);
                         reader.buildDirectory = reader.parseBuildDirectory(project.build);
                         if (project.profiles

--- a/src/main/fish/payara/project/MavenServerPluginReader.ts
+++ b/src/main/fish/payara/project/MavenServerPluginReader.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Copyright (c) 2020-2026 Payara Foundation and/or its affiliates and others.
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -20,26 +20,19 @@
 import * as fse from "fs-extra";
 import * as path from "path";
 import * as xml2js from "xml2js";
-import { PayaraMicroMavenPlugin } from "../micro/PayaraMicroMavenPlugin";
-import { MicroPluginReader } from "./MicroPluginReader";
+import { PayaraServerMavenPlugin } from "../server/maven/PayaraServerMavenPlugin";
 import { WorkspaceFolder } from "vscode";
 
-export class MavenMicroPluginReader implements MicroPluginReader {
+export class MavenServerPluginReader {
 
     private pluginFound: boolean = false;
-
-    private deployWar: boolean | undefined;
-
-    private useUberJar: boolean | undefined;
-
-    private exploded: boolean | undefined;
 
     public constructor(public workspaceFolder: WorkspaceFolder) {
         this.parsePom();
     }
 
     public parsePom(): void {
-        let reader: MavenMicroPluginReader = this;
+        let reader: MavenServerPluginReader = this;
         let pomPath = path.join(this.workspaceFolder.uri.fsPath, 'pom.xml');
         if (fse.existsSync(pomPath)) {
             let data = fse.readFileSync(pomPath);
@@ -51,7 +44,7 @@ export class MavenMicroPluginReader implements MicroPluginReader {
             );
             parser.parseString(data,
                 function (err: any, result: any) {
-                    if(err) {
+                    if (err) {
                         throw new Error(`Unable to parse file ${pomPath} : ${err.message}`);
                     }
                     if (result.project) {
@@ -68,32 +61,23 @@ export class MavenMicroPluginReader implements MicroPluginReader {
                                 reader.pluginFound = plugin !== undefined;
                             }
                         }
-                        if (plugin
-                            && Array.isArray(plugin.configuration)
-                            && plugin.configuration[0]) {
-                            let config = plugin.configuration[0];
-                            reader.deployWar = config.deployWar ? JSON.parse(config.deployWar[0]) : undefined;
-                            reader.exploded = config.exploded ? JSON.parse(config.exploded[0]) : undefined;
-                            reader.useUberJar = config.useUberJar ? JSON.parse(config.useUberJar[0]) : undefined;
-                        }
                     }
                 }
             );
         }
-
     }
 
     private parseBuild(build: any) {
         if (build
-            && build[0] 
+            && build[0]
             && build[0].plugins
             && build[0].plugins[0]
             && build[0].plugins[0].plugin) {
             for (let plugin of build[0].plugins[0].plugin) {
                 if (plugin.groupId
                     && plugin.artifactId
-                    && plugin.groupId[0] === PayaraMicroMavenPlugin.GROUP_ID
-                    && plugin.artifactId[0] === PayaraMicroMavenPlugin.ARTIFACT_ID) {
+                    && plugin.groupId[0] === PayaraServerMavenPlugin.GROUP_ID
+                    && plugin.artifactId[0] === PayaraServerMavenPlugin.ARTIFACT_ID) {
                     return plugin;
                 }
             }
@@ -103,18 +87,6 @@ export class MavenMicroPluginReader implements MicroPluginReader {
 
     public isPluginFound(): boolean {
         return this.pluginFound;
-    }
-
-    public isDeployWarEnabled(): boolean | undefined {
-        return this.deployWar;
-    }
-
-    public isUberJarEnabled(): boolean | undefined {
-        return this.useUberJar;
-    }
-
-    public isExplodedEnabled(): boolean | undefined {
-        return this.exploded;
     }
 
 }

--- a/src/main/fish/payara/server/maven/PayaraServerMavenInstance.ts
+++ b/src/main/fish/payara/server/maven/PayaraServerMavenInstance.ts
@@ -163,6 +163,12 @@ export class PayaraServerMavenInstance extends vscode.TreeItem implements vscode
         this.process = process;
     }
 
+    public sendCommand(input: string): void {
+        if (this.process?.stdin) {
+            this.process.stdin.write(input + '\n');
+        }
+    }
+
     public getOutputChannel(): vscode.OutputChannel {
         return this.outputChannel;
     }

--- a/src/main/fish/payara/server/maven/PayaraServerMavenInstance.ts
+++ b/src/main/fish/payara/server/maven/PayaraServerMavenInstance.ts
@@ -1,0 +1,180 @@
+'use strict';
+
+/*
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+import { ChildProcess } from "child_process";
+import * as path from "path";
+import * as _ from "lodash";
+import * as vscode from "vscode";
+import { Uri, workspace } from "vscode";
+import { JDKVersion } from "../start/JDKVersion";
+import { ProjectOutputWindowProvider } from "../../project/ProjectOutputWindowProvider";
+import { BuildSupport } from "../../project/BuildSupport";
+import { Build } from "../../project/Build";
+import { PayaraInstance } from "../../common/PayaraInstance";
+import { DeployOption } from "../../common/DeployOption";
+
+export class PayaraServerMavenInstance extends vscode.TreeItem implements vscode.QuickPickItem, PayaraInstance {
+
+    public label: string;
+
+    public description: string | undefined;
+
+    private outputChannel: vscode.OutputChannel;
+
+    private state: InstanceState = InstanceState.STOPPED;
+
+    private homePage: string | undefined;
+
+    private process: ChildProcess | undefined;
+
+    private buildPluginExist: boolean = false;
+
+    private debug: boolean = false;
+
+    private deployOption: string = DeployOption.DEFAULT;
+
+    private build: Build;
+
+    public iconPath?: Uri | vscode.ThemeIcon | { light: Uri; dark: Uri; };
+
+    constructor(private context: vscode.ExtensionContext, private name: string, private path: Uri) {
+        super(name);
+        this.label = name;
+        this.outputChannel = ProjectOutputWindowProvider.getInstance().get(name);
+        this.setState(InstanceState.STOPPED);
+        this.build = BuildSupport.getBuild(this, this.path);
+    }
+
+    public getBuild() {
+        return this.build;
+    }
+
+    public getName(): string {
+        return this.name;
+    }
+
+    public setName(name: string) {
+        this.name = name;
+    }
+
+    public getPath(): Uri {
+        return this.path;
+    }
+
+    public getJDKHome(): string | undefined {
+        return JDKVersion.getDefaultJDKHome();
+    }
+
+    public setJDKHome(jdkHome: string) {
+        workspace.getConfiguration("java").update("home", jdkHome);
+    }
+
+    public getDeployOption(): string {
+        return this.deployOption;
+    }
+
+    public setDeployOption(deployOption: string) {
+        this.deployOption = deployOption;
+    }
+
+    public setDebug(debug: boolean): void {
+        this.debug = debug;
+    }
+
+    public isDebug(): boolean {
+        return this.debug;
+    }
+
+    public isLoading(): boolean {
+        return this.state === InstanceState.LOADING;
+    }
+
+    public isStarted(): boolean {
+        return this.state === InstanceState.RUNNING;
+    }
+
+    public isStopped(): boolean {
+        return this.state === InstanceState.STOPPED;
+    }
+
+    public async setState(state: InstanceState): Promise<void> {
+        this.state = state;
+        this.iconPath = vscode.Uri.file(this.context.asAbsolutePath(path.join('resources', this.getIcon())));
+        this.contextValue = this.getState();
+        this.tooltip = this.getPath().fsPath;
+        vscode.commands.executeCommand('payara.server.maven.refresh', this);
+    }
+
+    public getState(): InstanceState {
+        return this.state;
+    }
+
+    public getIcon(): string {
+        let icon: string = `payara.svg`;
+        if (this.isLoading()) {
+            icon = `payara-loading.svg`;
+        } else if (this.isStarted()) {
+            if (this.isDebug()) {
+                icon = `payara-started-debug.svg`;
+            } else {
+                icon = `payara-started.svg`;
+            }
+        }
+        return icon;
+    }
+
+    public getHomePage() {
+        return this.homePage;
+    }
+
+    public setHomePage(homePage: string) {
+        this.homePage = homePage;
+    }
+
+    public isBuildPluginExist() {
+        return this.buildPluginExist;
+    }
+
+    public setBuildPluginExist(buildPluginExist: boolean) {
+        this.buildPluginExist = buildPluginExist;
+    }
+
+    public getProcess() {
+        return this.process;
+    }
+
+    public setProcess(process: ChildProcess) {
+        this.process = process;
+    }
+
+    public getOutputChannel(): vscode.OutputChannel {
+        return this.outputChannel;
+    }
+
+    public dispose() {
+        this.outputChannel.dispose();
+    }
+
+}
+
+export enum InstanceState {
+    RUNNING = "runningPayaraServerMaven",
+    LOADING = "loadingPayaraServerMaven",
+    STOPPED = "stoppedPayaraServerMaven"
+}

--- a/src/main/fish/payara/server/maven/PayaraServerMavenInstanceController.ts
+++ b/src/main/fish/payara/server/maven/PayaraServerMavenInstanceController.ts
@@ -1,0 +1,177 @@
+'use strict';
+
+/*
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+import * as _ from "lodash";
+import * as vscode from 'vscode';
+import { DebugConfiguration } from 'vscode';
+import { PayaraInstanceController } from "../../common/PayaraInstanceController";
+import { DebugManager } from '../../project/DebugManager';
+import { InstanceState, PayaraServerMavenInstance } from "./PayaraServerMavenInstance";
+import { PayaraServerMavenInstanceProvider } from './PayaraServerMavenInstanceProvider';
+
+export class PayaraServerMavenInstanceController extends PayaraInstanceController {
+
+    constructor(
+        context: vscode.ExtensionContext,
+        private instanceProvider: PayaraServerMavenInstanceProvider,
+        private extensionPath: string) {
+        super(context);
+    }
+
+    public async startServerMaven(payaraServerMaven: PayaraServerMavenInstance, debug: boolean, callback?: (status: boolean) => any): Promise<void> {
+        if (!payaraServerMaven.isStopped()) {
+            vscode.window.showErrorMessage('Payara Server Maven instance already running.');
+            return;
+        }
+        let workspaceFolder = vscode.workspace.getWorkspaceFolder(payaraServerMaven.getPath());
+
+        let debugConfig: DebugConfiguration | undefined;
+        if (debug && workspaceFolder) {
+            let debugManager: DebugManager = new DebugManager();
+            debugConfig = debugManager.getPayaraConfig(workspaceFolder, debugManager.getDefaultServerMavenConfig());
+        }
+        try {
+            payaraServerMaven.setDebug(debug);
+            await payaraServerMaven.setState(InstanceState.LOADING);
+            let process = payaraServerMaven.getBuild()
+                .startPayaraServerMaven(debugConfig,
+                    async data => {
+                        if (!payaraServerMaven.isStarted()) {
+                            if (debugConfig && data.indexOf("Listening for transport dt_socket at address:") > -1) {
+                                vscode.debug.startDebugging(workspaceFolder, debugConfig);
+                                debugConfig = undefined;
+                            }
+                            if (data.indexOf("application deployed successfully") > -1) {
+                                await payaraServerMaven.setState(InstanceState.RUNNING);
+                            }
+                        }
+                    },
+                    async (code) => {
+                        await payaraServerMaven.setState(InstanceState.STOPPED);
+                        if (code !== 0) {
+                            console.warn(`startServerMaven task failed with exit code ${code}`);
+                        }
+                    },
+                    async (error) => {
+                        vscode.window.showErrorMessage(`Error on executing startServerMaven task: ${error.message}`);
+                        await payaraServerMaven.setState(InstanceState.STOPPED);
+                    }
+                );
+            if (process) {
+                payaraServerMaven.setProcess(process);
+            } else {
+                await payaraServerMaven.setState(InstanceState.STOPPED);
+            }
+        } catch (error) {
+            vscode.window.showErrorMessage("Error on executing startServerMaven task:" + ((error instanceof Error) ? error.message : error));
+            await payaraServerMaven.setState(InstanceState.STOPPED);
+        }
+    }
+
+    public async devServerMaven(payaraServerMaven: PayaraServerMavenInstance, debug: boolean = false, callback?: (status: boolean) => any): Promise<void> {
+        if (!payaraServerMaven.isStopped()) {
+            vscode.window.showErrorMessage('Payara Server Maven instance already running.');
+            return;
+        }
+        let workspaceFolder = vscode.workspace.getWorkspaceFolder(payaraServerMaven.getPath());
+
+        let debugConfig: DebugConfiguration | undefined;
+        if (debug && workspaceFolder) {
+            let debugManager: DebugManager = new DebugManager();
+            debugConfig = debugManager.getPayaraConfig(workspaceFolder, debugManager.getDefaultServerMavenConfig());
+        }
+        try {
+            payaraServerMaven.setDebug(debug);
+            await payaraServerMaven.setState(InstanceState.LOADING);
+            let process = payaraServerMaven.getBuild()
+                .devPayaraServerMaven(
+                    debugConfig,
+                    async data => {
+                        if (!payaraServerMaven.isStarted()) {
+                            if (debugConfig && data.indexOf("Listening for transport dt_socket at address:") > -1) {
+                                vscode.debug.startDebugging(workspaceFolder, debugConfig);
+                                debugConfig = undefined;
+                            }
+                            if (data.indexOf("application deployed successfully") > -1) {
+                                await payaraServerMaven.setState(InstanceState.RUNNING);
+                            }
+                        }
+                    },
+                    async (code) => {
+                        await payaraServerMaven.setState(InstanceState.STOPPED);
+                        if (code !== 0) {
+                            console.warn(`devServerMaven task failed with exit code ${code}`);
+                        }
+                    },
+                    async (error) => {
+                        vscode.window.showErrorMessage(`Error on executing devServerMaven task: ${error.message}`);
+                        await payaraServerMaven.setState(InstanceState.STOPPED);
+                    }
+                );
+            if (process) {
+                payaraServerMaven.setProcess(process);
+            } else {
+                await payaraServerMaven.setState(InstanceState.STOPPED);
+            }
+        } catch (error) {
+            vscode.window.showErrorMessage("Error on executing devServerMaven task:" + ((error instanceof Error) ? error.message : error));
+            await payaraServerMaven.setState(InstanceState.STOPPED);
+        }
+    }
+
+    public async stopServerMaven(payaraServerMaven: PayaraServerMavenInstance): Promise<void> {
+        if (payaraServerMaven.isStopped()) {
+            vscode.window.showErrorMessage('Payara Server Maven instance not running.');
+            return;
+        }
+        const process = payaraServerMaven.getProcess();
+        if (!process || !process.pid) {
+            vscode.window.showErrorMessage('No running Payara Server Maven process found.');
+            return;
+        }
+        try {
+            payaraServerMaven.getBuild()
+                .stopPayaraServerMaven(
+                    process.pid,
+                    async (code: number) => {
+                        payaraServerMaven.setDebug(false);
+                        await payaraServerMaven.setState(InstanceState.STOPPED);
+                        if (code !== 0) {
+                            vscode.window.showErrorMessage(`stopServerMaven task failed with exit code ${code}`);
+                        }
+                    },
+                    async (error: { message: any; }) => {
+                        vscode.window.showErrorMessage(`Error on executing stopServerMaven task: ${error.message}`);
+                        payaraServerMaven.setDebug(false);
+                        await payaraServerMaven.setState(InstanceState.STOPPED);
+                    }
+                );
+        } catch (error) {
+            vscode.window.showErrorMessage("Error on executing stopServerMaven task:" + ((error instanceof Error) ? error.message : error));
+        }
+    }
+
+    public async refreshServerMavenList(): Promise<void> {
+        vscode.commands.executeCommand('payara.server.maven.refresh.all');
+    }
+
+    updateConfig(): void {
+    }
+
+}

--- a/src/main/fish/payara/server/maven/PayaraServerMavenInstanceController.ts
+++ b/src/main/fish/payara/server/maven/PayaraServerMavenInstanceController.ts
@@ -24,13 +24,15 @@ import { PayaraInstanceController } from "../../common/PayaraInstanceController"
 import { DebugManager } from '../../project/DebugManager';
 import { InstanceState, PayaraServerMavenInstance } from "./PayaraServerMavenInstance";
 import { PayaraServerMavenInstanceProvider } from './PayaraServerMavenInstanceProvider';
+import { PayaraAIChatViewProvider } from '../../ai/PayaraAIChatViewProvider';
 
 export class PayaraServerMavenInstanceController extends PayaraInstanceController {
 
     constructor(
         context: vscode.ExtensionContext,
         private instanceProvider: PayaraServerMavenInstanceProvider,
-        private extensionPath: string) {
+        private extensionPath: string,
+        private chatProvider?: PayaraAIChatViewProvider) {
         super(context);
     }
 
@@ -52,6 +54,7 @@ export class PayaraServerMavenInstanceController extends PayaraInstanceControlle
             let process = payaraServerMaven.getBuild()
                 .startPayaraServerMaven(debugConfig,
                     async data => {
+                        this.chatProvider?.handleData(data);
                         if (!payaraServerMaven.isStarted()) {
                             if (debugConfig && data.indexOf("Listening for transport dt_socket at address:") > -1) {
                                 vscode.debug.startDebugging(workspaceFolder, debugConfig);
@@ -59,11 +62,13 @@ export class PayaraServerMavenInstanceController extends PayaraInstanceControlle
                             }
                             if (data.indexOf("application deployed successfully") > -1) {
                                 await payaraServerMaven.setState(InstanceState.RUNNING);
+                                this.chatProvider?.onInstanceStarted(payaraServerMaven);
                             }
                         }
                     },
                     async (code) => {
                         await payaraServerMaven.setState(InstanceState.STOPPED);
+                        this.chatProvider?.onInstanceStopped();
                         if (code !== 0) {
                             console.warn(`startServerMaven task failed with exit code ${code}`);
                         }
@@ -71,6 +76,7 @@ export class PayaraServerMavenInstanceController extends PayaraInstanceControlle
                     async (error) => {
                         vscode.window.showErrorMessage(`Error on executing startServerMaven task: ${error.message}`);
                         await payaraServerMaven.setState(InstanceState.STOPPED);
+                        this.chatProvider?.onInstanceStopped();
                     }
                 );
             if (process) {
@@ -103,6 +109,7 @@ export class PayaraServerMavenInstanceController extends PayaraInstanceControlle
                 .devPayaraServerMaven(
                     debugConfig,
                     async data => {
+                        this.chatProvider?.handleData(data);
                         if (!payaraServerMaven.isStarted()) {
                             if (debugConfig && data.indexOf("Listening for transport dt_socket at address:") > -1) {
                                 vscode.debug.startDebugging(workspaceFolder, debugConfig);
@@ -110,11 +117,13 @@ export class PayaraServerMavenInstanceController extends PayaraInstanceControlle
                             }
                             if (data.indexOf("application deployed successfully") > -1) {
                                 await payaraServerMaven.setState(InstanceState.RUNNING);
+                                this.chatProvider?.onInstanceStarted(payaraServerMaven);
                             }
                         }
                     },
                     async (code) => {
                         await payaraServerMaven.setState(InstanceState.STOPPED);
+                        this.chatProvider?.onInstanceStopped();
                         if (code !== 0) {
                             console.warn(`devServerMaven task failed with exit code ${code}`);
                         }
@@ -122,6 +131,7 @@ export class PayaraServerMavenInstanceController extends PayaraInstanceControlle
                     async (error) => {
                         vscode.window.showErrorMessage(`Error on executing devServerMaven task: ${error.message}`);
                         await payaraServerMaven.setState(InstanceState.STOPPED);
+                        this.chatProvider?.onInstanceStopped();
                     }
                 );
             if (process) {

--- a/src/main/fish/payara/server/maven/PayaraServerMavenInstanceProvider.ts
+++ b/src/main/fish/payara/server/maven/PayaraServerMavenInstanceProvider.ts
@@ -1,0 +1,53 @@
+'use strict';
+
+/*
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+import * as vscode from "vscode";
+import * as _ from "lodash";
+import { PayaraServerMavenInstance } from "./PayaraServerMavenInstance";
+import { BuildSupport } from "../../project/BuildSupport";
+import { Maven } from "../../project/Maven";
+
+export class PayaraServerMavenInstanceProvider {
+
+    private instances: Map<string, PayaraServerMavenInstance> = new Map<string, PayaraServerMavenInstance>();
+
+    constructor(public context: vscode.ExtensionContext) {
+    }
+
+    public getServerMavenInstances(): PayaraServerMavenInstance[] {
+        let instances: Array<PayaraServerMavenInstance> = new Array<PayaraServerMavenInstance>();
+        if (vscode.workspace.workspaceFolders) {
+            for (let folder of vscode.workspace.workspaceFolders) {
+                try {
+                    let instance = this.instances.get(folder.uri.fsPath);
+                    if (!instance) {
+                        let build = BuildSupport.getBuild(null, folder.uri);
+                        instance = new PayaraServerMavenInstance(this.context, build.getBuildReader().getArtifactId(), folder.uri);
+                        this.instances.set(folder.uri.fsPath, instance);
+                    }
+                    instances.push(instance);
+                } catch (e) {
+                    // ..skip
+                }
+            }
+        }
+        return instances;
+    }
+
+}

--- a/src/main/fish/payara/server/maven/PayaraServerMavenInstanceProvider.ts
+++ b/src/main/fish/payara/server/maven/PayaraServerMavenInstanceProvider.ts
@@ -18,6 +18,7 @@
  */
 
 import * as vscode from "vscode";
+import * as path from "path";
 import * as _ from "lodash";
 import { PayaraServerMavenInstance } from "./PayaraServerMavenInstance";
 import { BuildSupport } from "../../project/BuildSupport";
@@ -30,6 +31,10 @@ export class PayaraServerMavenInstanceProvider {
     constructor(public context: vscode.ExtensionContext) {
     }
 
+    public getAllInstances(): PayaraServerMavenInstance[] {
+        return Array.from(this.instances.values());
+    }
+
     public getServerMavenInstances(): PayaraServerMavenInstance[] {
         let instances: Array<PayaraServerMavenInstance> = new Array<PayaraServerMavenInstance>();
         if (vscode.workspace.workspaceFolders) {
@@ -38,12 +43,13 @@ export class PayaraServerMavenInstanceProvider {
                     let instance = this.instances.get(folder.uri.fsPath);
                     if (!instance) {
                         let build = BuildSupport.getBuild(null, folder.uri);
-                        instance = new PayaraServerMavenInstance(this.context, build.getBuildReader().getArtifactId(), folder.uri);
+                        const artifactId = build.getBuildReader().getArtifactId() || path.basename(folder.uri.fsPath);
+                        instance = new PayaraServerMavenInstance(this.context, artifactId, folder.uri);
                         this.instances.set(folder.uri.fsPath, instance);
                     }
                     instances.push(instance);
                 } catch (e) {
-                    // ..skip
+                    // skip folders that aren't valid Maven projects
                 }
             }
         }

--- a/src/main/fish/payara/server/maven/PayaraServerMavenPlugin.ts
+++ b/src/main/fish/payara/server/maven/PayaraServerMavenPlugin.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * Copyright (c) 2020-2026 Payara Foundation and/or its affiliates and others.
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,14 +17,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-export namespace  PayaraMicroMavenPlugin {
+export namespace PayaraServerMavenPlugin {
 
-    export const ARTIFACT_ID = 'payara-micro-maven-plugin';
     export const GROUP_ID = 'fish.payara.maven.plugins';
+    export const ARTIFACT_ID = 'payara-server-maven-plugin';
     export const START_GOAL = 'start';
     export const DEV_GOAL = 'dev';
     export const STOP_GOAL = 'stop';
-    export const BUNDLE_GOAL = 'bundle';
-    export const RELOAD_GOAL = 'reload';
+    export const DEPLOY_GOAL = 'deploy';
+    export const UNDEPLOY_GOAL = 'undeploy';
 
 }

--- a/src/main/fish/payara/server/maven/PayaraServerMavenTreeDataProvider.ts
+++ b/src/main/fish/payara/server/maven/PayaraServerMavenTreeDataProvider.ts
@@ -1,0 +1,50 @@
+'use strict';
+
+/*
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+import * as vscode from "vscode";
+import * as _ from "lodash";
+import { TreeItem } from "vscode";
+import { PayaraServerMavenInstanceProvider } from "./PayaraServerMavenInstanceProvider";
+
+export class PayaraServerMavenTreeDataProvider implements vscode.TreeDataProvider<TreeItem> {
+
+    onDidChangeTreeDataListener: vscode.EventEmitter<TreeItem> = new vscode.EventEmitter<TreeItem>();
+
+    onDidChangeTreeData: vscode.Event<TreeItem> = this.onDidChangeTreeDataListener.event;
+
+    constructor(private context: vscode.ExtensionContext, private instanceProvider: PayaraServerMavenInstanceProvider) {
+    }
+
+    public refresh(item: TreeItem): void {
+        this.onDidChangeTreeDataListener.fire(item);
+    }
+
+    public async getTreeItem(item: TreeItem): Promise<TreeItem> {
+        return item;
+    }
+
+    public async getChildren(item?: TreeItem): Promise<TreeItem[]> {
+        let instances: Array<TreeItem> = new Array<TreeItem>();
+        if (!item) {
+            instances = this.instanceProvider.getServerMavenInstances();
+        }
+        return instances;
+    }
+
+}

--- a/src/test/ai/testAIModelFetch.ts
+++ b/src/test/ai/testAIModelFetch.ts
@@ -1,0 +1,138 @@
+'use strict';
+
+/**
+ * Standalone test for AIModelFetcher logic (local providers only — cloud providers use static lists).
+ * Run: npx ts-node --project tsconfig.json src/test/ai/testAIModelFetch.ts <PROVIDER> [LOCATION]
+ *
+ * Examples (local providers):
+ *   npx ts-node --project tsconfig.json src/test/ai/testAIModelFetch.ts OLLAMA http://localhost:11434
+ *   npx ts-node --project tsconfig.json src/test/ai/testAIModelFetch.ts LM_STUDIO http://localhost:1234
+ *   npx ts-node --project tsconfig.json src/test/ai/testAIModelFetch.ts CUSTOM_OPEN_AI http://localhost:8080
+ *
+ * Cloud providers (OPEN_AI, ANTHROPIC, GOOGLE, GROQ, MISTRAL, DEEPSEEK, DEEPINFRA)
+ * use a static curated model list — no network call needed.
+ */
+
+import * as https from 'https';
+import * as http from 'http';
+import { URL } from 'url';
+
+const CLOUD_MODELS: Record<string, string[]> = {
+    OPEN_AI: [
+        'o3', 'o3-mini', 'o4-mini', 'o1', 'o1-mini',
+        'gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'gpt-4', 'gpt-3.5-turbo',
+    ],
+    ANTHROPIC: [
+        'claude-opus-4-5', 'claude-sonnet-4-5', 'claude-haiku-4-5',
+        'claude-3-5-sonnet-20241022', 'claude-3-5-haiku-20241022',
+        'claude-3-opus-20240229', 'claude-3-sonnet-20240229', 'claude-3-haiku-20240307',
+    ],
+    GOOGLE: [
+        'gemini-2.5-pro', 'gemini-2.0-flash', 'gemini-2.0-flash-exp',
+        'gemini-1.5-pro', 'gemini-1.5-flash', 'gemini-1.0-pro',
+    ],
+    GROQ: [
+        'llama-3.3-70b-versatile', 'llama-3.1-70b-versatile', 'llama-3.1-8b-instant',
+        'llama3-70b-8192', 'llama3-8b-8192', 'mixtral-8x7b-32768', 'gemma2-9b-it',
+    ],
+    MISTRAL: [
+        'mistral-large-latest', 'mistral-medium-latest', 'mistral-small-latest',
+        'codestral-latest', 'open-mixtral-8x22b', 'open-mixtral-8x7b', 'open-mistral-7b',
+    ],
+    DEEPSEEK: [
+        'deepseek-chat', 'deepseek-coder', 'deepseek-reasoner',
+    ],
+    DEEPINFRA: [
+        'meta-llama/Meta-Llama-3.1-70B-Instruct', 'meta-llama/Meta-Llama-3.1-8B-Instruct',
+        'mistralai/Mistral-7B-Instruct-v0.3', 'microsoft/WizardLM-2-8x22B',
+        'Qwen/Qwen2-72B-Instruct',
+    ],
+};
+
+const LOCAL_PROVIDERS = new Set(['OLLAMA', 'LM_STUDIO', 'GPT4ALL']);
+
+function fetchJson(options: ReturnType<typeof buildLocalRequestOptions>): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const requester = options.protocol === 'https:' ? https : http;
+        const req = requester.request(
+            { hostname: options.hostname, port: options.port, path: options.path, method: options.method, headers: options.headers, timeout: 15000 },
+            (res) => {
+                let data = '';
+                res.on('data', (chunk) => { data += chunk; });
+                res.on('end', () => {
+                    if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+                        resolve(data);
+                    } else {
+                        let detail = '';
+                        try { detail = JSON.parse(data)?.error?.message || data.slice(0, 300); } catch { detail = data.slice(0, 300); }
+                        reject(new Error(`HTTP ${res.statusCode}: ${detail}`));
+                    }
+                });
+            }
+        );
+        req.on('timeout', () => { req.destroy(); reject(new Error('Request timed out')); });
+        req.on('error', (err) => reject(err));
+        req.end();
+    });
+}
+
+function buildLocalRequestOptions(provider: string, providerLocation: string) {
+    let baseUrl: string;
+    let path: string;
+    const headers: Record<string, string> = { 'Accept': 'application/json' };
+    switch (provider) {
+        case 'OLLAMA':    baseUrl = providerLocation || 'http://localhost:11434'; path = '/api/tags'; break;
+        case 'LM_STUDIO': baseUrl = providerLocation || 'http://localhost:1234';  path = '/v1/models'; break;
+        default:          baseUrl = providerLocation || 'http://localhost:4891';  path = '/v1/models'; break;
+    }
+    const parsed = new URL(baseUrl);
+    const protocol = parsed.protocol;
+    const hostname = parsed.hostname;
+    const port = parsed.port ? parseInt(parsed.port, 10) : protocol === 'https:' ? 443 : 80;
+    const basePath = parsed.pathname.replace(/\/$/, '');
+    return { hostname, port, path: basePath + path, method: 'GET', headers, protocol };
+}
+
+function parseLocalModelIds(provider: string, body: string): string[] {
+    const json = JSON.parse(body);
+    if (provider === 'OLLAMA') {
+        return (json.models as Array<{ name: string }> || []).map(m => m.name).filter(Boolean);
+    }
+    return (json.data as Array<{ id: string }> || []).map(m => m.id).filter(Boolean);
+}
+
+async function main() {
+    const [, , provider = 'OPEN_AI', providerLocation = ''] = process.argv;
+
+    if (CLOUD_MODELS[provider]) {
+        const models = [...CLOUD_MODELS[provider]].sort((a, b) => a.localeCompare(b));
+        console.log(`Provider : ${provider} (static list)`);
+        console.log(`\n✓ ${models.length} models:\n`);
+        models.forEach((m, i) => console.log(`  ${i + 1}. ${m}`));
+        return;
+    }
+
+    if (!LOCAL_PROVIDERS.has(provider) && provider !== 'CUSTOM_OPEN_AI') {
+        console.error(`Unknown provider: ${provider}`);
+        process.exit(1);
+    }
+
+    const options = buildLocalRequestOptions(provider, providerLocation);
+    console.log(`Provider : ${provider}`);
+    console.log(`Endpoint : ${options.protocol}//${options.hostname}:${options.port}${options.path}`);
+    console.log('Fetching...\n');
+
+    try {
+        const body = await fetchJson(options);
+        const models = parseLocalModelIds(provider, body);
+        models.sort((a, b) => a.localeCompare(b));
+        console.log(`✓ ${models.length} models returned:\n`);
+        models.slice(0, 20).forEach((m, i) => console.log(`  ${i + 1}. ${m}`));
+        if (models.length > 20) { console.log(`  ... and ${models.length - 20} more`); }
+    } catch (err) {
+        console.error(`✗ Error: ${err instanceof Error ? err.message : err}`);
+        process.exit(1);
+    }
+}
+
+main();

--- a/src/test/unit/ai/CloudModels.test.ts
+++ b/src/test/unit/ai/CloudModels.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+'use strict';
+
+import * as assert from 'assert';
+import { CLOUD_MODELS } from '../../../main/fish/payara/ai/AIModelFetcher';
+
+const EXPECTED_PROVIDERS = ['OPEN_AI', 'ANTHROPIC', 'GOOGLE', 'GROQ', 'MISTRAL', 'DEEPSEEK', 'DEEPINFRA'];
+
+describe('CLOUD_MODELS — coverage', () => {
+
+    it('defines an entry for every expected cloud provider', () => {
+        for (const p of EXPECTED_PROVIDERS) {
+            assert.ok(p in CLOUD_MODELS, `Missing provider: ${p}`);
+        }
+    });
+
+    it('every provider has at least one model', () => {
+        for (const [provider, models] of Object.entries(CLOUD_MODELS)) {
+            assert.ok(models.length > 0, `${provider} has no models`);
+        }
+    });
+
+    it('no model ID is an empty string or only whitespace', () => {
+        for (const [provider, models] of Object.entries(CLOUD_MODELS)) {
+            for (const id of models) {
+                assert.ok(id.trim().length > 0, `${provider} contains blank model ID`);
+            }
+        }
+    });
+
+    it('no duplicate model IDs within a provider', () => {
+        for (const [provider, models] of Object.entries(CLOUD_MODELS)) {
+            const set = new Set(models);
+            assert.strictEqual(set.size, models.length, `${provider} has duplicate model IDs`);
+        }
+    });
+
+});
+
+describe('CLOUD_MODELS — OPEN_AI', () => {
+
+    it('includes gpt-4o and gpt-4o-mini', () => {
+        assert.ok(CLOUD_MODELS.OPEN_AI.includes('gpt-4o'));
+        assert.ok(CLOUD_MODELS.OPEN_AI.includes('gpt-4o-mini'));
+    });
+
+    it('model IDs do not contain the "openai/" prefix (already stripped)', () => {
+        for (const id of CLOUD_MODELS.OPEN_AI) {
+            assert.ok(!id.startsWith('openai/'), `ID should not have openai/ prefix: ${id}`);
+        }
+    });
+
+});
+
+describe('CLOUD_MODELS — ANTHROPIC', () => {
+
+    it('includes at least one claude-3 and one claude-sonnet-4 model', () => {
+        const hasClaude3 = CLOUD_MODELS.ANTHROPIC.some(m => m.startsWith('claude-3'));
+        const hasClaude4 = CLOUD_MODELS.ANTHROPIC.some(m => m.includes('claude-sonnet-4') || m.includes('claude-opus-4') || m.includes('claude-haiku-4'));
+        assert.ok(hasClaude3, 'Expected at least one claude-3 model');
+        assert.ok(hasClaude4, 'Expected at least one claude-4-series model');
+    });
+
+    it('model IDs do not contain the "anthropic/" prefix', () => {
+        for (const id of CLOUD_MODELS.ANTHROPIC) {
+            assert.ok(!id.startsWith('anthropic/'), `ID should not have anthropic/ prefix: ${id}`);
+        }
+    });
+
+});
+
+describe('CLOUD_MODELS — GOOGLE', () => {
+
+    it('includes at least one gemini model', () => {
+        assert.ok(CLOUD_MODELS.GOOGLE.some(m => m.startsWith('gemini-')));
+    });
+
+});
+
+describe('CLOUD_MODELS — GROQ', () => {
+
+    it('includes llama and mixtral models', () => {
+        const hasLlama   = CLOUD_MODELS.GROQ.some(m => m.includes('llama'));
+        const hasMixtral = CLOUD_MODELS.GROQ.some(m => m.includes('mixtral'));
+        assert.ok(hasLlama,   'Expected a llama model');
+        assert.ok(hasMixtral, 'Expected a mixtral model');
+    });
+
+});
+
+describe('CLOUD_MODELS — MISTRAL', () => {
+
+    it('includes mistral-large-latest', () => {
+        assert.ok(CLOUD_MODELS.MISTRAL.includes('mistral-large-latest'));
+    });
+
+});
+
+describe('CLOUD_MODELS — DEEPSEEK', () => {
+
+    it('includes deepseek-chat', () => {
+        assert.ok(CLOUD_MODELS.DEEPSEEK.includes('deepseek-chat'));
+    });
+
+});

--- a/src/test/unit/extension/ExtensionDeactivate.test.ts
+++ b/src/test/unit/extension/ExtensionDeactivate.test.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+'use strict';
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as cp from 'child_process';
+import { EventEmitter } from 'events';
+import { ChildProcess } from 'child_process';
+import { JavaUtils } from '../../../main/fish/payara/server/tooling/utils/JavaUtils';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMockProc(pid = 55555): ChildProcess {
+    const emitter = new EventEmitter() as any;
+    emitter.pid = pid;
+    emitter.killed = false;
+    // Simulate real behaviour: kill() marks the process as dead.
+    emitter.kill = sinon.stub().callsFake(() => { emitter.killed = true; });
+    emitter.stdin = null;
+    emitter.stdout = null;
+    emitter.stderr = null;
+    return emitter as ChildProcess;
+}
+
+/**
+ * Mirrors the kill loop inside killAllMavenInstances() in extension.ts exactly.
+ * Tests here exercise that contract for both PayaraServerMavenInstance and
+ * PayaraMicroInstance, which share the same getProcess() interface.
+ */
+function runKillInstances(instances: Array<{ getProcess(): ChildProcess | undefined }>): void {
+    for (const instance of instances) {
+        const proc = instance.getProcess();
+        if (proc?.pid && !proc.killed) {
+            try {
+                if (JavaUtils.IS_WIN) {
+                    cp.execSync(`taskkill /F /T /PID ${proc.pid}`, { stdio: 'ignore' });
+                } else {
+                    proc.kill('SIGTERM');
+                }
+            } catch (_) { /* already gone */ }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('kill-instances logic (deactivate contract)', () => {
+
+    let execSyncStub: sinon.SinonStub;
+    let originalIsWin: boolean;
+
+    beforeEach(() => {
+        execSyncStub = sinon.stub(cp, 'execSync');
+        originalIsWin = JavaUtils.IS_WIN;
+        JavaUtils.IS_WIN = false; // default to Unix path; individual tests override as needed
+    });
+
+    afterEach(() => {
+        JavaUtils.IS_WIN = originalIsWin;
+        sinon.restore();
+    });
+
+    it('kills a running Micro instance: has PID → kill → process is dead', () => {
+        const proc = makeMockProc(22222);
+
+        // 1. Instance is running
+        assert.ok(proc.pid, 'Micro instance must have a PID while running');
+        assert.strictEqual(proc.killed, false, 'Micro instance must be alive before deactivate');
+
+        // 2. Extension deactivates
+        runKillInstances([{ getProcess: () => proc }]);
+
+        // 3. Instance is dead
+        assert.strictEqual(proc.killed, true, 'Micro instance must be killed after deactivate');
+        sinon.assert.calledWith(proc.kill as sinon.SinonStub, 'SIGTERM');
+    });
+
+    it('kills both Server Maven and Micro instances on deactivate', () => {
+        const serverProc = makeMockProc(11111);
+        const microProc  = makeMockProc(22222);
+
+        // 1. Both instances running
+        assert.strictEqual(serverProc.killed, false);
+        assert.strictEqual(microProc.killed,  false);
+
+        // 2. Extension deactivates — both providers are iterated
+        runKillInstances([
+            { getProcess: () => serverProc },
+            { getProcess: () => microProc  },
+        ]);
+
+        // 3. Both instances dead
+        assert.strictEqual(serverProc.killed, true, 'Server Maven instance must be killed');
+        assert.strictEqual(microProc.killed,  true, 'Micro instance must be killed');
+    });
+
+    it('skips a Micro instance that had already stopped before deactivate', () => {
+        const proc = makeMockProc();
+
+        // Instance stopped on its own before VS Code closed
+        (proc as any).killed = true;
+        assert.strictEqual(proc.killed, true, 'precondition: process already dead');
+
+        runKillInstances([{ getProcess: () => proc }]);
+
+        // kill() must not be called a second time
+        sinon.assert.notCalled(proc.kill as sinon.SinonStub);
+    });
+
+    it('skips an instance that never fully started (no PID)', () => {
+        const proc = makeMockProc();
+        (proc as any).pid = undefined;
+
+        // No PID — process never launched successfully
+        assert.strictEqual(proc.pid, undefined);
+
+        runKillInstances([{ getProcess: () => proc }]);
+
+        sinon.assert.notCalled(proc.kill as sinon.SinonStub);
+    });
+
+    it('skips instances that have no process attached at all', () => {
+        assert.doesNotThrow(() =>
+            runKillInstances([{ getProcess: () => undefined }])
+        );
+    });
+
+    it('continues killing remaining instances if one kill() throws', () => {
+        const failProc = makeMockProc(33333);
+        const okProc   = makeMockProc(44444);
+
+        // First instance's kill throws (e.g. ESRCH — no such process)
+        (failProc.kill as sinon.SinonStub).callsFake(() => { throw new Error('ESRCH'); });
+
+        assert.doesNotThrow(() =>
+            runKillInstances([
+                { getProcess: () => failProc },
+                { getProcess: () => okProc   },
+            ])
+        );
+
+        // Second instance must still be killed despite the first throwing
+        assert.strictEqual(okProc.killed, true, 'surviving instance must still be killed');
+    });
+
+    it('uses taskkill on Windows: has PID → taskkill → PID targeted', () => {
+        JavaUtils.IS_WIN = true;
+        const proc = makeMockProc(77777);
+
+        // 1. Instance running on Windows
+        assert.ok(proc.pid);
+        assert.strictEqual(proc.killed, false);
+
+        // 2. Extension deactivates
+        runKillInstances([{ getProcess: () => proc }]);
+
+        // 3. taskkill was called for this specific PID
+        sinon.assert.calledWithMatch(
+            execSyncStub,
+            sinon.match(/taskkill.*\/PID 77777/i)
+        );
+    });
+
+});

--- a/src/test/unit/maven/MavenDetect.test.ts
+++ b/src/test/unit/maven/MavenDetect.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+'use strict';
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { WorkspaceFolder } from 'vscode';
+import { Maven } from '../../../main/fish/payara/project/Maven';
+
+function makeWorkspaceFolder(fsPath: string): WorkspaceFolder {
+    return { uri: { fsPath } as any, name: 'test', index: 0 };
+}
+
+describe('Maven.detect()', () => {
+
+    let tempDir: string;
+
+    beforeEach(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'payara-maven-test-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('returns true when pom.xml exists in the workspace root', () => {
+        fs.writeFileSync(path.join(tempDir, 'pom.xml'), '<project/>');
+        assert.strictEqual(Maven.detect(makeWorkspaceFolder(tempDir)), true);
+    });
+
+    it('returns false when pom.xml does not exist', () => {
+        assert.strictEqual(Maven.detect(makeWorkspaceFolder(tempDir)), false);
+    });
+
+    it('returns false when only build.gradle exists (Gradle project)', () => {
+        fs.writeFileSync(path.join(tempDir, 'build.gradle'), '');
+        assert.strictEqual(Maven.detect(makeWorkspaceFolder(tempDir)), false);
+    });
+
+    it('returns false for a non-existent directory', () => {
+        const noSuchDir = path.join(tempDir, 'does-not-exist');
+        assert.strictEqual(Maven.detect(makeWorkspaceFolder(noSuchDir)), false);
+    });
+
+});

--- a/src/test/unit/micro/MicroKillOnExit.test.ts
+++ b/src/test/unit/micro/MicroKillOnExit.test.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+'use strict';
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as cp from 'child_process';
+import * as os from 'os';
+import { EventEmitter } from 'events';
+import { ChildProcess } from 'child_process';
+import { Maven } from '../../../main/fish/payara/project/Maven';
+import { JavaUtils } from '../../../main/fish/payara/server/tooling/utils/JavaUtils';
+import { WorkspaceFolder } from 'vscode';
+
+function makeFakeWorkspaceFolder(): WorkspaceFolder {
+    // os.tmpdir() has no pom.xml so Maven.detect() → false and readBuildConfig() is a no-op.
+    return { uri: { fsPath: os.tmpdir() } as any, name: 'test', index: 0 };
+}
+
+function makeMockProc(pid = 99999): ChildProcess {
+    const emitter = new EventEmitter() as any;
+    emitter.pid = pid;
+    emitter.killed = false;
+    // Simulate the real behaviour: kill() marks the process as killed.
+    emitter.kill = sinon.stub().callsFake(() => { emitter.killed = true; });
+    emitter.stdin = null;
+    emitter.stdout = null;
+    emitter.stderr = null;
+    return emitter as ChildProcess;
+}
+
+/** Returns the last listener registered on process 'exit' (the one just added by registerKillOnExit). */
+function getLastExitListener(): Function {
+    const listeners = process.listeners('exit') as Function[];
+    return listeners[listeners.length - 1];
+}
+
+describe('Maven.registerKillOnExit — process listener lifecycle', () => {
+
+    let maven: Maven;
+    let execSyncStub: sinon.SinonStub;
+    let originalIsWin: boolean;
+
+    beforeEach(() => {
+        maven = new Maven(null, makeFakeWorkspaceFolder());
+        execSyncStub = sinon.stub(cp, 'execSync');
+        originalIsWin = JavaUtils.IS_WIN;
+    });
+
+    afterEach(() => {
+        JavaUtils.IS_WIN = originalIsWin;
+        sinon.restore();
+    });
+
+    it('adds exactly one process exit listener when an instance starts', () => {
+        const proc = makeMockProc();
+        const before = process.listenerCount('exit');
+
+        // Instance starts → register kill guard
+        maven.registerKillOnExit(proc);
+
+        assert.strictEqual(process.listenerCount('exit'), before + 1);
+
+        // Cleanup: let the proc exit normally so the listener is removed.
+        proc.emit('exit', 0);
+    });
+
+    it('removes the listener after the instance stops normally', () => {
+        const proc = makeMockProc();
+        const before = process.listenerCount('exit');
+
+        // Instance starts
+        maven.registerKillOnExit(proc);
+        assert.strictEqual(process.listenerCount('exit'), before + 1);
+
+        // Instance stops on its own (clean exit)
+        proc.emit('exit', 0);
+
+        assert.strictEqual(process.listenerCount('exit'), before, 'listener must be cleaned up after normal exit');
+    });
+
+    it('kills the instance (Unix) when VS Code host exits mid-run', () => {
+        JavaUtils.IS_WIN = false;
+        const proc = makeMockProc(12345);
+
+        // 1. Instance is running — has PID, not yet killed
+        assert.ok(proc.pid, 'instance should have a PID while running');
+        assert.strictEqual(proc.killed, false, 'instance should be alive before kill');
+
+        // 2. Register kill guard when instance starts
+        maven.registerKillOnExit(proc);
+
+        // 3. VS Code host exits → kill guard fires
+        getLastExitListener()();
+
+        // 4. Instance is now dead
+        assert.strictEqual(proc.killed, true, 'instance should be killed after host exit');
+        sinon.assert.calledWith(proc.kill as sinon.SinonStub, 'SIGTERM');
+
+        proc.emit('exit', 0);
+    });
+
+    it('calls taskkill on Windows when VS Code host exits mid-run', () => {
+        JavaUtils.IS_WIN = true;
+        const proc = makeMockProc(12345);
+
+        // 1. Instance is running
+        assert.ok(proc.pid);
+        assert.strictEqual(proc.killed, false);
+
+        // 2. Register kill guard
+        maven.registerKillOnExit(proc);
+
+        // 3. Host exits
+        getLastExitListener()();
+
+        // 4. taskkill was invoked for this PID
+        sinon.assert.calledWithMatch(
+            execSyncStub,
+            sinon.match(/taskkill.*\/PID 12345/i)
+        );
+
+        proc.emit('exit', 0);
+    });
+
+    it('does not kill an instance that already stopped before the host exits', () => {
+        JavaUtils.IS_WIN = false;
+        const proc = makeMockProc();
+
+        maven.registerKillOnExit(proc);
+
+        // Instance stops normally before the host exits
+        (proc as any).killed = true;
+
+        getLastExitListener()();
+
+        sinon.assert.notCalled(proc.kill as sinon.SinonStub);
+
+        proc.emit('exit', 0);
+    });
+
+    it('does not kill an instance that never fully started (no PID)', () => {
+        JavaUtils.IS_WIN = false;
+        const proc = makeMockProc();
+        (proc as any).pid = undefined;
+
+        // 1. No PID — instance never got off the ground
+        assert.strictEqual(proc.pid, undefined);
+
+        maven.registerKillOnExit(proc);
+
+        getLastExitListener()();
+
+        sinon.assert.notCalled(proc.kill as sinon.SinonStub);
+
+        proc.emit('exit', 0);
+    });
+
+    it('tracks two concurrent Micro instances independently', () => {
+        JavaUtils.IS_WIN = false;
+        const proc1 = makeMockProc(11111);
+        const proc2 = makeMockProc(22222);
+        const before = process.listenerCount('exit');
+
+        // Both instances start
+        assert.strictEqual(proc1.killed, false);
+        assert.strictEqual(proc2.killed, false);
+
+        maven.registerKillOnExit(proc1);
+        maven.registerKillOnExit(proc2);
+        assert.strictEqual(process.listenerCount('exit'), before + 2);
+
+        // proc1 stops normally — only its listener is removed
+        proc1.emit('exit', 0);
+        assert.strictEqual(proc1.killed, false, 'proc1 exited on its own, not force-killed');
+        assert.strictEqual(process.listenerCount('exit'), before + 1);
+
+        // VS Code host then exits — proc2 is still running, should be killed
+        getLastExitListener()();
+        assert.strictEqual(proc2.killed, true, 'proc2 should be killed on host exit');
+
+        proc2.emit('exit', 0);
+        assert.strictEqual(process.listenerCount('exit'), before);
+    });
+
+});

--- a/src/test/unit/micro/PayaraMicroPlugin.test.ts
+++ b/src/test/unit/micro/PayaraMicroPlugin.test.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+'use strict';
+
+import * as assert from 'assert';
+import { PayaraMicroMavenPlugin } from '../../../main/fish/payara/micro/PayaraMicroMavenPlugin';
+
+describe('PayaraMicroMavenPlugin — plugin coordinates', () => {
+
+    it('should use the correct Maven GROUP_ID', () => {
+        assert.strictEqual(PayaraMicroMavenPlugin.GROUP_ID, 'fish.payara.maven.plugins');
+    });
+
+    it('should use the correct ARTIFACT_ID', () => {
+        assert.strictEqual(PayaraMicroMavenPlugin.ARTIFACT_ID, 'payara-micro-maven-plugin');
+    });
+
+    it('should expose start, dev, stop, bundle and reload goals', () => {
+        assert.strictEqual(PayaraMicroMavenPlugin.START_GOAL,  'start');
+        assert.strictEqual(PayaraMicroMavenPlugin.DEV_GOAL,    'dev');
+        assert.strictEqual(PayaraMicroMavenPlugin.STOP_GOAL,   'stop');
+        assert.strictEqual(PayaraMicroMavenPlugin.BUNDLE_GOAL, 'bundle');
+        assert.strictEqual(PayaraMicroMavenPlugin.RELOAD_GOAL, 'reload');
+    });
+
+});
+
+describe('PayaraMicroMavenPlugin — Maven command format', () => {
+
+    const G = PayaraMicroMavenPlugin.GROUP_ID;
+    const A = PayaraMicroMavenPlugin.ARTIFACT_ID;
+
+    it('dev command is a single plugin goal (no package phase)', () => {
+        const cmd = `mvn ${G}:${A}:${PayaraMicroMavenPlugin.DEV_GOAL}`;
+        assert.strictEqual(cmd, 'mvn fish.payara.maven.plugins:payara-micro-maven-plugin:dev');
+        assert.ok(!cmd.includes('package'));
+    });
+
+    it('stop command is a single plugin goal', () => {
+        const cmd = `mvn ${G}:${A}:${PayaraMicroMavenPlugin.STOP_GOAL}`;
+        assert.strictEqual(cmd, 'mvn fish.payara.maven.plugins:payara-micro-maven-plugin:stop');
+    });
+
+    it('bundle command includes "mvn install" before the bundle goal', () => {
+        const cmd = `mvn install ${G}:${A}:${PayaraMicroMavenPlugin.BUNDLE_GOAL}`;
+        assert.ok(cmd.startsWith('mvn install'));
+        assert.ok(cmd.includes(':bundle'));
+        assert.strictEqual(cmd, 'mvn install fish.payara.maven.plugins:payara-micro-maven-plugin:bundle');
+    });
+
+    it('start (uber-jar) command runs install + bundle + start goals', () => {
+        const cmd = `mvn install ${G}:${A}:${PayaraMicroMavenPlugin.BUNDLE_GOAL} ${G}:${A}:${PayaraMicroMavenPlugin.START_GOAL}`;
+        assert.ok(cmd.includes(':bundle'));
+        assert.ok(cmd.includes(':start'));
+        assert.strictEqual(cmd, 'mvn install fish.payara.maven.plugins:payara-micro-maven-plugin:bundle fish.payara.maven.plugins:payara-micro-maven-plugin:start');
+    });
+
+    it('start (exploded-war) command compiles and deploys WAR before starting', () => {
+        const cmd = `mvn resources:resources compiler:compile war:exploded -Dexploded=true -DdeployWar=true ${G}:${A}:${PayaraMicroMavenPlugin.START_GOAL}`;
+        assert.ok(cmd.includes('war:exploded'));
+        assert.ok(cmd.includes('-DdeployWar=true'));
+        assert.ok(cmd.includes(':start'));
+    });
+
+    it('reload command recompiles before running the reload goal', () => {
+        const cmd = `mvn resources:resources compiler:compile war:exploded ${G}:${A}:${PayaraMicroMavenPlugin.RELOAD_GOAL}`;
+        assert.ok(cmd.includes('compiler:compile'));
+        assert.ok(cmd.includes(':reload'));
+    });
+
+    it('debug start appends -Ddebug JVM agent string', () => {
+        const port = 5005;
+        const base = `mvn ${G}:${A}:${PayaraMicroMavenPlugin.START_GOAL}`;
+        const cmd = `${base} -Ddebug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${port}`;
+        assert.ok(cmd.includes('-Ddebug='));
+        assert.ok(cmd.includes(`address=${port}`));
+        assert.ok(cmd.includes('dt_socket'));
+    });
+
+    it('hot-deploy start appends -DhotDeploy=true', () => {
+        const base = `mvn resources:resources compiler:compile war:exploded -Dexploded=true -DdeployWar=true ${G}:${A}:${PayaraMicroMavenPlugin.START_GOAL}`;
+        const cmd = `${base} -DhotDeploy=true`;
+        assert.ok(cmd.includes('-DhotDeploy=true'));
+    });
+
+    it('hot-reload with metadata change appends -DmetadataChanged=true', () => {
+        const base = `mvn resources:resources compiler:compile war:exploded ${G}:${A}:${PayaraMicroMavenPlugin.RELOAD_GOAL}`;
+        const cmd = `${base} -DhotDeploy=true -DmetadataChanged=true`;
+        assert.ok(cmd.includes('-DmetadataChanged=true'));
+    });
+
+});

--- a/src/test/unit/server/PayaraServerMavenPlugin.test.ts
+++ b/src/test/unit/server/PayaraServerMavenPlugin.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+'use strict';
+
+import * as assert from 'assert';
+import { PayaraServerMavenPlugin } from '../../../main/fish/payara/server/maven/PayaraServerMavenPlugin';
+
+describe('PayaraServerMavenPlugin — plugin coordinates', () => {
+
+    it('should use the correct Maven GROUP_ID', () => {
+        assert.strictEqual(PayaraServerMavenPlugin.GROUP_ID, 'fish.payara.maven.plugins');
+    });
+
+    it('should use the correct ARTIFACT_ID', () => {
+        assert.strictEqual(PayaraServerMavenPlugin.ARTIFACT_ID, 'payara-server-maven-plugin');
+    });
+
+    it('should expose start, dev, stop, deploy and undeploy goals', () => {
+        assert.strictEqual(PayaraServerMavenPlugin.START_GOAL,   'start');
+        assert.strictEqual(PayaraServerMavenPlugin.DEV_GOAL,     'dev');
+        assert.strictEqual(PayaraServerMavenPlugin.STOP_GOAL,    'stop');
+        assert.strictEqual(PayaraServerMavenPlugin.DEPLOY_GOAL,  'deploy');
+        assert.strictEqual(PayaraServerMavenPlugin.UNDEPLOY_GOAL,'undeploy');
+    });
+
+});
+
+describe('PayaraServerMavenPlugin — Maven command format', () => {
+
+    const G = PayaraServerMavenPlugin.GROUP_ID;
+    const A = PayaraServerMavenPlugin.ARTIFACT_ID;
+
+    it('start command includes "mvn package" and the start goal', () => {
+        const cmd = `mvn package ${G}:${A}:${PayaraServerMavenPlugin.START_GOAL}`;
+        assert.ok(cmd.startsWith('mvn package'), 'should begin with mvn package');
+        assert.ok(cmd.includes(':start'), 'should contain :start goal');
+        assert.strictEqual(cmd, 'mvn package fish.payara.maven.plugins:payara-server-maven-plugin:start');
+    });
+
+    it('dev command includes "mvn package" and the dev goal', () => {
+        const cmd = `mvn package ${G}:${A}:${PayaraServerMavenPlugin.DEV_GOAL}`;
+        assert.ok(cmd.includes(':dev'), 'should contain :dev goal');
+        assert.strictEqual(cmd, 'mvn package fish.payara.maven.plugins:payara-server-maven-plugin:dev');
+    });
+
+    it('stop command does NOT include "mvn package"', () => {
+        const cmd = `mvn ${G}:${A}:${PayaraServerMavenPlugin.STOP_GOAL}`;
+        assert.ok(!cmd.includes('package'), 'stop should not run the package phase');
+        assert.strictEqual(cmd, 'mvn fish.payara.maven.plugins:payara-server-maven-plugin:stop');
+    });
+
+    it('debug start appends -Ddebug=true and -DdebugPort', () => {
+        const port = 9009;
+        const base = `mvn package ${G}:${A}:${PayaraServerMavenPlugin.START_GOAL}`;
+        const cmd = `${base} -Ddebug=true -DdebugPort=${port}`;
+        assert.ok(cmd.includes('-Ddebug=true'));
+        assert.ok(cmd.includes(`-DdebugPort=${port}`));
+    });
+
+    it('debug dev appends -Dpayara.debug=true and -Dpayara.debug.port', () => {
+        const port = 9009;
+        const base = `mvn package ${G}:${A}:${PayaraServerMavenPlugin.DEV_GOAL}`;
+        const cmd = `${base} -Dpayara.debug=true -Dpayara.debug.port=${port}`;
+        assert.ok(cmd.includes('-Dpayara.debug=true'));
+        assert.ok(cmd.includes(`-Dpayara.debug.port=${port}`));
+    });
+
+    it('stop command appends -DprocessId', () => {
+        const pid = 12345;
+        const base = `mvn ${G}:${A}:${PayaraServerMavenPlugin.STOP_GOAL}`;
+        const cmd = `${base} -DprocessId=${pid}`;
+        assert.ok(cmd.includes(`-DprocessId=${pid}`));
+    });
+
+});

--- a/src/test/unit/vscode-mock.js
+++ b/src/test/unit/vscode-mock.js
@@ -1,0 +1,71 @@
+'use strict';
+
+// Intercept require('vscode') before any source module loads it.
+const Module = require('module');
+const original = Module._resolveFilename.bind(Module);
+Module._resolveFilename = function (request, parent, isMain, options) {
+    if (request === 'vscode') { return 'vscode'; }
+    return original(request, parent, isMain, options);
+};
+
+class EventEmitter {
+    constructor() { this.event = () => {}; }
+    fire() {}
+    dispose() {}
+}
+
+const vscodeMock = {
+    workspace: {
+        getConfiguration: () => ({
+            get: (_key) => undefined,
+            update: () => Promise.resolve(),
+        }),
+        workspaceFolders: undefined,
+        onDidSaveTextDocument: () => ({ dispose: () => {} }),
+        onDidChangeConfiguration: () => ({ dispose: () => {} }),
+        getWorkspaceFolder: () => undefined,
+    },
+    window: {
+        showErrorMessage: () => Promise.resolve(undefined),
+        showWarningMessage: () => Promise.resolve(undefined),
+        showInformationMessage: () => Promise.resolve(undefined),
+        createTerminal: () => ({ show: () => {} }),
+        createQuickPick: () => ({
+            show: () => {}, hide: () => {}, dispose: () => {},
+            onDidAccept: () => {}, onDidHide: () => {},
+            items: [], busy: false, placeholder: '', ignoreFocusOut: false,
+        }),
+        withProgress: (_opts, task) => task({ report: () => {} }),
+        registerTreeDataProvider: () => ({ dispose: () => {} }),
+    },
+    commands: {
+        registerCommand: () => ({ dispose: () => {} }),
+        executeCommand: () => Promise.resolve(),
+    },
+    EventEmitter,
+    Uri: {
+        file: (p) => ({ fsPath: p, toString: () => `file://${p}` }),
+        parse: (s) => ({ fsPath: s, toString: () => s }),
+    },
+    ProgressLocation: { Notification: 15, Window: 10, SourceControl: 1 },
+    ConfigurationTarget: { Global: 1, Workspace: 2, WorkspaceFolder: 3 },
+    debug: {
+        startDebugging: () => Promise.resolve(true),
+        onDidTerminateDebugSession: () => ({ dispose: () => {} }),
+    },
+    extensions: {
+        getExtension: () => undefined,
+    },
+    TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+    ThemeIcon: class ThemeIcon { constructor(id) { this.id = id; } },
+};
+
+require.cache['vscode'] = {
+    id: 'vscode',
+    filename: 'vscode',
+    loaded: true,
+    exports: vscodeMock,
+    parent: null,
+    children: [],
+    paths: [],
+};


### PR DESCRIPTION
Add Payara Server Maven Plugin support with Dev Mode and Debug

  - Add Server Projects tree view for payara-server-maven-plugin (start, debug, stop)
  - Add dev mode for both Server Maven and Micro plugins with distinct lightning bolt icons
  - Add "Start (Dev Mode) in Debug" for both plugins — attaches VS Code Java debugger when server is ready
  - Fix debug port to be configurable via .vscode/launch.json (auto-created on first use, default 5005)
  - Both Server Maven and Micro providers now show all Maven projects — no plugin declaration required in pom.xml
  
##  Depends on:
  - https://github.com/payara/ecosystem-maven/pull/546
  - https://github.com/payara/ecosystem-ai/
  
  ## Verify 
  - Build ecosystem-ai and ecosystem-maven/pull/546
  - Generate Payara Maven project from https://start.payara.fish/ and update the plugin version:
  ```
    <groupId>fish.payara.maven.plugins</groupId>
    <artifactId>payara-server-maven-plugin</artifactId>
    <version>1.3.0-SNAPSHOT</version>
  ```
- Open the project in VSCode
- Goto Server project and press the start button

<img width="2265" height="1774" alt="image" src="https://github.com/user-attachments/assets/54649bf5-be4b-4d11-ba41-3d63f42461e5" />
